### PR TITLE
Update workable badges / icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,18 +53,21 @@
           "icon": "${bootable-icon}"
         }
       ],
-      "icons/imagesList": [
+      "icons/image": [
         {
           "when": "ostree.bootable in imageLabelKeys",
           "icon": "${bootable-icon}"
         }
       ],
-      "badges/imagesList": [
+      "badges/image": [
         {
           "when": "ostree.bootable in imageLabelKeys",
           "badge": {
-            "name": "bootc",
-            "style": "bg-green-600"
+            "label": "bootc",
+            "color": {
+              "dark": "bg-sky-300",
+              "light": "bg-sky-300"
+            }
           }
         }
       ]


### PR DESCRIPTION
Update workable badges / icons

Since the upstream changes have changed paramters (example, we use
'label' instead of 'name'), I've updated bootc for it to work.

Depends on: https://github.com/containers/podman-desktop/pull/5557

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
