### PR TITLE
feat: improve quick pick formatting

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,15 +73,24 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
 
     extensionApi.commands.registerCommand('bootc.image.build', async image => {
       const telemetryData: Record<string, any> = {};
-      
-      const selectedType = await extensionApi.window.showQuickPick(['qcow2', 'ami', 'raw', 'iso'], {
-        placeHolder: 'Select image type',
-      });
-      if (!selectedType) {
+
+      const selection = await extensionApi.window.showQuickPick(
+        [
+          { label: 'QCOW2', detail: 'QEMU image (.qcow2)', format: 'qemu' },
+          { label: 'AMI', detail: 'Amazon Machine Image (.ami)', format: 'ami' },
+          { label: 'RAW', detail: 'Raw image (.raw) with an MBR or GPT partition table', format: 'raw' },
+          { label: 'ISO', detail: 'ISO standard disk image (.iso) for flashing media and using EFI', format: 'iso' },
+        ],
+        {
+          title: 'Select the type of disk image to create',
+        },
+      );
+      if (!selection) {
         telemetryData.canceled = true;
         telemetryLogger.logUsage('buildDiskImage', telemetryData);
         return;
       }
+      const selectedType = selection.format;
       telemetryData.imageType = selectedType;
 
       const selectedFolder = await extensionApi.window.showInputBox({


### PR DESCRIPTION
Improves the quick pick items, adding detail for each. I didn't use the description attribute b/c the layout is slightly off (another PF removal impact?) and to me it is easier to read like this.

Fixes #49.

<img width="691" alt="Screenshot 2024-01-18 at 11 03 41 AM" src="https://github.com/containers/podman-desktop-extension-bootc/assets/19958075/3169f376-e539-4c46-8ddf-afd801bbfee0">
