### PR TITLE
feat: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug 🐞
+description: Report a bug report
+labels: [kind/bug 🐞]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a bug report, please search for the behaviour in the existing issues.
+
+        ---
+
+        Thank you for taking the time to file a bug report. To address this bug as fast as possible, we need some information.
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug description
+      description: What happened?
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: "Which operating system are you on? Please provide the version as well. If you are on a Mac, please specify Apple silicon or Intel."
+      placeholder: "macOS Ventura 13.4 (Arm), Windows 11"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of the software are you running?
+      options:
+        - "next (development version)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: What steps do we need to take to reproduce this error?
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: If applicable, provide relevant log output.
+      render: shell
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots here.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     id: version
     attributes:
       label: Version
-      description: What version of the software are you running?
+      description: What version of the bootable container extension are you running?
       options:
         - "next (development version)"
     validations:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,42 @@
+name: Enhancement ✨
+description: Suggest an enhancement to an existing feature
+labels: [kind/enhancement ✨]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a new enhancement, please search for potential existing issues.
+
+        ---
+
+        Thank you for taking the time to file an enhancement request, we appreciate and value your time to help the project!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your enhancement related to a problem? Please describe
+      description: A clear and concise description of what the problem is.
+      placeholder: I'm always frustrated when [...]
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots here.

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,25 @@
+name: Epic ⚡
+description: A high-level feature
+labels: [kind/epic ⚡]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Epics are normally created by the development team, to group a set of related features and plan work across multiple sprints.
+        The features this epic includes are referenced with the text of the epic.
+
+  - type: textarea
+    id: domain
+    attributes:
+      label: Epic domain
+      description: A clear and concise description of the feature area or domain that this epic will address.
+      placeholder: The bootable container extension should support [...]
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature 💡
+description: Suggest an idea for this project
+labels: [kind/feature 💡]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a feature request, please search for potential existing issues.
+
+        ---
+
+        Thank you for taking the time to file a feature request, we appreciate and value your time to help the project!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem? Please describe
+      description: A clear and concise description of what the problem is.
+      placeholder: I'm always frustrated when [...]
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### What does this PR do?
+
+### Screenshot / video of UI
+
+<!-- If this PR is changing UI, please include 
+screenshots or screencasts showing the difference -->
+
+### What issues does this PR fix or reference?
+
+<!-- Include any related issues from Podman Desktop 
+repository (or from another issue tracker). -->
+
+### How to test this PR?
+
+<!-- Please explain steps to reproduce -->


### PR DESCRIPTION
Adds issue and PR templates. Almost identical to what we have in Podman Desktop, just removed one option that didn't apply, removed releases, and changed a reference or two from Podman Desktop to this extension.

Part of #24.