### PR TITLE
feat: add erroring out / refactor / add tests

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+// Image related
+export const bootcImageBuilderContainerName = '-bootc-image-builder';
+export const bootcImageBuilderName = 'quay.io/centos-bootc/bootc-image-builder:latest-1705709685';

--- a/src/container-utils.spec.ts
+++ b/src/container-utils.spec.ts
@@ -1,0 +1,90 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import * as extensionApi from '@podman-desktop/api';
+import {
+  getContainerEngine,
+  pullImage,
+  createAndStartContainer,
+  waitForContainerToExit,
+  removeContainerIfExists,
+} from './container-utils';
+
+// Mocks and utilities
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    containerEngine: {
+      pullImage: vi.fn(),
+      createContainer: vi.fn(),
+      listContainers: vi.fn(),
+      deleteContainer: vi.fn(),
+    },
+    provider: {
+      getContainerConnections: vi.fn(() => [
+        // Mocked container connections
+        {
+          connection: {
+            type: 'podman',
+            status: () => 'started',
+          },
+        },
+      ]),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('getContainerEngine should return a running podman engine', async () => {
+  const engine = await getContainerEngine();
+  expect(engine).toBeDefined();
+  expect(engine.type).toBe('podman');
+});
+
+test('pullImage should call pullImage from containerEngine', async () => {
+  await pullImage('someImage');
+  expect(extensionApi.containerEngine.pullImage).toBeCalled();
+});
+
+// Test createAndStartContainer
+test('createAndStartContainer should create and return container ID', async () => {
+  const createContainerMock = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (extensionApi.containerEngine as any).createContainer = createContainerMock;
+
+  createContainerMock.mockResolvedValue({ id: '1234' });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const containerId = await createAndStartContainer('', {} as any);
+  expect(containerId).toBe('1234');
+});
+
+// Test waitForContainerToExit
+test('waitForContainerToExit should wait for container to exit', async () => {
+  const listContainersMock = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (extensionApi.containerEngine as any).listContainers = listContainersMock;
+  listContainersMock.mockResolvedValue([{ Names: '1234', Id: '1234', State: 'exited', Status: 'Exited (0)' }]);
+
+  await expect(waitForContainerToExit('1234')).resolves.toBeUndefined();
+});
+
+// Test removeContainerIfExists
+test('removeContainerIfExists should remove existing container', async () => {
+  const listContainersMock = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (extensionApi.containerEngine as any).listContainers = listContainersMock;
+  listContainersMock.mockResolvedValue([{ Names: '/1234' }]);
+
+  const deleteContainerMock = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (extensionApi.containerEngine as any).deleteContainer = deleteContainerMock;
+
+  await removeContainerIfExists('', '1234');
+  expect(deleteContainerMock).toBeCalled();
+});

--- a/src/container-utils.ts
+++ b/src/container-utils.ts
@@ -1,0 +1,125 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { ContainerCreateOptions } from '@podman-desktop/api';
+import * as extensionApi from '@podman-desktop/api';
+
+// Get the running container engine
+export async function getContainerEngine(): Promise<extensionApi.ContainerProviderConnection> {
+  // Get all engines
+  const providerConnections = extensionApi.provider.getContainerConnections();
+
+  // Keep only the podman engine
+  // TODO: match by engineId from `image.engineId` instead of just looking for the first podman
+  const podmanConnections = providerConnections.filter(
+    providerConnection => providerConnection.connection.type === 'podman',
+  );
+
+  if (podmanConnections.length < 1) {
+    throw new Error('No podman engine. Cannot preload images');
+  }
+
+  // Get the running podman engine(s)
+  const runningPodmanConnections = providerConnections.filter(
+    providerConnection => providerConnection.connection.status() === 'started',
+  );
+  if (runningPodmanConnections.length < 1) {
+    throw new Error('No podman engine running. Cannot preload images');
+  }
+
+  return runningPodmanConnections[0].connection;
+}
+
+// Pull the image
+export async function pullImage(image: string) {
+  console.log('Pulling image: ', image);
+  try {
+    const containerConnection = await getContainerEngine();
+    await extensionApi.containerEngine.pullImage(containerConnection, image, () => {});
+  } catch (e) {
+    console.log(e);
+    throw new Error('There was an error pulling the image: ' + e);
+  }
+}
+
+// Create and start a container based upon the container create options
+// For functions such as start / stop / delete, we need the engineID passed in..
+export async function createAndStartContainer(engineId: string, options: ContainerCreateOptions): Promise<string> {
+  console.log('engineID: ', engineId);
+  try {
+    const result = await extensionApi.containerEngine.createContainer(engineId, options);
+    return result.id;
+  } catch (e) {
+    console.log(e);
+    throw new Error('There was an error creating the container: ' + e);
+  }
+}
+/*
+Wait for the container to exit, if it exits with a non-zero exit code, throw an error
+TODO: Add timeout?
+*/
+export async function waitForContainerToExit(containerId: string): Promise<void> {
+  let containerRunning = true;
+
+  while (containerRunning) {
+    console.log('Waiting for container to exit: ', containerId);
+    await extensionApi.containerEngine.listContainers().then(containers => {
+      containers.forEach(container => {
+        if (container.Id === containerId && container.State === 'exited') {
+          // Let's stop the loop if the container has exited / stopped
+          containerRunning = false;
+          // Container.status reports "ex. Exited (1) Less than a second ago" when it
+          // errors out, and Exited (0) when it succeeds. So we check for that.
+          if (!container.Status.includes('Exited (0)')) {
+            throw new Error('There was an error with the build, the container exited with a non-zero exit code.');
+          }
+        }
+      });
+    });
+
+    // Check every second
+    await new Promise(r => setTimeout(r, 1000));
+  }
+}
+
+// List containers, find the container by name if it exists, and then delete it.
+export async function removeContainerIfExists(engineId: string, container: string) {
+  try {
+    // List all the containers and check to see  if it exists
+    const containers = await extensionApi.containerEngine.listContainers();
+    console.log('Containers: ', containers);
+
+    // Find the one that matches the name we are looking for
+    // The PD API is a bit weird in that it uses 'Names' for the container name instead of
+    // Name and it's an array of strings with '/' appended to the beginning
+    // So we need to check for that as well.
+    let containerExists = false;
+    containers.forEach(c => {
+      if (c.Names.includes('/' + container)) {
+        containerExists = true;
+      }
+    });
+
+    // Delete the container if it exists
+    if (containerExists) {
+      await extensionApi.containerEngine.deleteContainer(engineId, container);
+    }
+  } catch (e) {
+    console.log(e);
+    throw new Error('There was an error removing the container: ' + e);
+  }
+}


### PR DESCRIPTION
feat: add erroring out / refactor / add tests

### What does this PR do?

* Checks to see if the image has actually errored out before continuing
* Moves the "container utility" functions to a separate file
* Adds a lot more tests

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/38

### How to test this PR?

1. Start a build image
2. Stop the container during the build process.
3. It will fail as the container image will exit with error (1), rather
   than saying success

<!-- Please explain steps to reproduce -->
