### PR TITLE
nit: fix saying qcow2 not qemu

### DIFF
--- a/src/build-disk-image.ts
+++ b/src/build-disk-image.ts
@@ -35,7 +35,7 @@ export async function buildDiskImage(image: any) {
 
   const selection = await extensionApi.window.showQuickPick(
     [
-      { label: 'QCOW2', detail: 'QEMU image (.qcow2)', format: 'qemu' },
+      { label: 'QCOW2', detail: 'QEMU image (.qcow2)', format: 'qcow2' },
       { label: 'AMI', detail: 'Amazon Machine Image (.ami)', format: 'ami' },
       { label: 'RAW', detail: 'Raw image (.raw) with an MBR or GPT partition table', format: 'raw' },
       { label: 'ISO', detail: 'ISO standard disk image (.iso) for flashing media and using EFI', format: 'iso' },


### PR DESCRIPTION
nit: fix saying qcow2 not qemu

### What does this PR do?

Small fix as the CLI type is qcow2 not qemu

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

N/A

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

You should be able to select qcow2 now without it erroring

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
