### PR TITLE
chore: update provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Support for bootable OS containers (bootc) and generating disk images",
   "version": "0.1.0-next",
   "icon": "icon-dark.png",
-  "publisher": "redhat",
+  "publisher": "podman-desktop",
   "license": "Apache-2.0",
   "engines": {
     "podman-desktop": "^1.6.0"


### PR DESCRIPTION
### What does this PR do?

I happened to notice that our extensions storage is in redhat.bootc-extension while minikube is in podman-desktop.minikube. Seems we forgot to update our provider when the repo was created in this org.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A