### PR TITLE
feat: remember image build history

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,9 +20,13 @@ import type { ExtensionContext } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { launchVFKit } from './launch-vfkit';
 import { buildDiskImage } from './build-disk-image';
+import { History } from './history';
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   console.log('starting bootc extension');
+
+  const history = new History(extensionContext.storagePath);
+  await history.loadFile();
 
   extensionContext.subscriptions.push(
     extensionApi.commands.registerCommand('bootc.vfkit', async container => {
@@ -30,7 +34,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     }),
 
     extensionApi.commands.registerCommand('bootc.image.build', async image => {
-      await buildDiskImage(image);
+      await buildDiskImage(image, history);
     }),
   );
 }

--- a/src/history.spec.ts
+++ b/src/history.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { History } from './history';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('check simple add and get', async () => {
+  vi.mock('node:fs', async () => {
+    return {
+      readFile: vi.fn().mockImplementation(() => '[]'),
+      writeFile: vi.fn().mockImplementation(() => Promise.resolve()),
+      existsSync: vi.fn().mockImplementation(() => true),
+    };
+  });
+
+  const history: History = new History('test');
+
+  await history.addImageBuild('a', 'b', 'c');
+
+  expect(history.getLastLocation()).toEqual('c');
+});
+
+test('check get returns latest after multiple adds', async () => {
+  vi.mock('node:fs', async () => {
+    return {
+      readFile: vi.fn().mockImplementation(() => '[]'),
+      writeFile: vi.fn().mockImplementation(() => Promise.resolve()),
+      existsSync: vi.fn().mockImplementation(() => true),
+    };
+  });
+
+  const history: History = new History('test');
+
+  await history.addImageBuild('a0', 'b0', 'c0');
+  await history.addImageBuild('a1', 'b1', 'c1');
+  await history.addImageBuild('a2', 'b2', 'c2');
+
+  expect(history.getLastLocation()).toEqual('c2');
+});

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,0 +1,92 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
+
+const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
+
+const filename = 'history.json';
+
+interface ImageInfo {
+  image: string;
+  type: string;
+  location: string;
+}
+
+export class History {
+  infos: ImageInfo[] = [];
+
+  constructor(private readonly storagePath: string) {}
+
+  async loadFile() {
+    // check if history file exists, and load history from previous run
+    try {
+      if (!fs.existsSync(this.storagePath)) {
+        return;
+      }
+
+      const filePath = path.resolve(this.storagePath, filename);
+      if (!fs.existsSync(filePath)) {
+        return;
+      }
+
+      const infoBuffer = await readFile(filePath);
+      this.infos = JSON.parse(infoBuffer.toString('utf8'));
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  public getLastLocation(): string | undefined {
+    if (this.infos.length === 0) {
+      return undefined;
+    } else {
+      return this.infos[0].location;
+    }
+  }
+
+  public async addImageBuild(image: string, type: string, location: string) {
+    // remove any previous entry
+    this.infos = this.infos.filter(info => info.image !== image || info.type !== type);
+
+    // add new item to the front
+    this.infos = [{ image, type, location } as ImageInfo, ...this.infos];
+
+    // cull the full list at the last 100
+    if (this.infos.length > 100) {
+      this.infos.slice(0, 100);
+    }
+
+    this.saveFile().catch((err: unknown) => console.error('Unable to save history', err));
+  }
+
+  public async saveFile() {
+    try {
+      if (!fs.existsSync(this.storagePath)) {
+        await promisify(fs.mkdir)(this.storagePath);
+      }
+
+      const filePath = path.resolve(this.storagePath, filename);
+      await writeFile(filePath, JSON.stringify(this.infos, undefined, 2));
+    } catch (err: unknown) {
+      console.error(err);
+    }
+  }
+}

--- a/src/history.ts
+++ b/src/history.ts
@@ -15,12 +15,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import * as fs from 'node:fs';
+import { existsSync } from 'node:fs';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import * as path from 'node:path';
-import { promisify } from 'node:util';
-
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
 
 const filename = 'history.json';
 
@@ -38,17 +35,17 @@ export class History {
   async loadFile() {
     // check if history file exists, and load history from previous run
     try {
-      if (!fs.existsSync(this.storagePath)) {
+      if (!existsSync(this.storagePath)) {
         return;
       }
 
       const filePath = path.resolve(this.storagePath, filename);
-      if (!fs.existsSync(filePath)) {
+      if (!existsSync(filePath)) {
         return;
       }
 
-      const infoBuffer = await readFile(filePath);
-      this.infos = JSON.parse(infoBuffer.toString('utf8'));
+      const infoBuffer = await readFile(filePath, 'utf8');
+      this.infos = JSON.parse(infoBuffer);
     } catch (err) {
       console.error(err);
     }
@@ -79,8 +76,8 @@ export class History {
 
   public async saveFile() {
     try {
-      if (!fs.existsSync(this.storagePath)) {
-        await promisify(fs.mkdir)(this.storagePath);
+      if (!existsSync(this.storagePath)) {
+        await mkdir(this.storagePath);
       }
 
       const filePath = path.resolve(this.storagePath, filename);


### PR DESCRIPTION
### What does this PR do?

Saves the image, type, and folder for every image build. For today, this just lets us remember the history of image build folders and default to the same folder the next time you build.

Why save more than the last folder, and why save the image name and type too? There is no registry of past disk images (like we have with container images, or containers), e.g. they aren't saved to an OCI registry. Although there's some initial discussion to do this, there no timeline.

Saving this data means we have a list of all past images and at least some options for providing actions on them, e.g. launching vfkit from the (container) image instead of just from the ephemeral container that was used to build it. Including the data in this PR means we don't need to deal with an imminent breaking format change.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #30.

### How to test this PR?

Build an image, restart Podman Desktop, and confirm it remembers the output folder the next time you build.