### PR TITLE
chore: stopping build log in console

### DIFF
--- a/src/build-disk-image.ts
+++ b/src/build-disk-image.ts
@@ -138,7 +138,6 @@ export async function buildDiskImage(imageData: unknown, history: History) {
         // Step 3.1 Since we have started the container, we can now go get the logs
         await logContainer(image, containerId, progress, data => {
           logData += data;
-          console.log('log:' + logData);
         });
 
         // Step 4. Wait for the container to exit


### PR DESCRIPTION
### What does this PR do?

The build log is a lot of volume, and you can see it live in the containers view or stored after in our log file, so stop writing it to the console log as well.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A