### PR TITLE
feat: add launch action to bootable images

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
           "command": "bootc.image.build",
           "title": "Build Disk Image",
           "when": "ostree.bootable in imageLabelKeys"
+        },
+        {
+          "command": "bootc.vfkit",
+          "title": "Launch as VM",
+          "when": "ostree.bootable in imageLabelKeys"
         }
       ],
       "dashboard/container": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
 
   extensionContext.subscriptions.push(
     extensionApi.commands.registerCommand('bootc.vfkit', async container => {
-      await launchVFKit(container);
+      await launchVFKit(container, history);
     }),
 
     extensionApi.commands.registerCommand('bootc.image.build', async image => {

--- a/src/history.spec.ts
+++ b/src/history.spec.ts
@@ -58,3 +58,27 @@ test('check get returns latest after multiple adds', async () => {
 
   expect(history.getLastLocation()).toEqual('c2');
 });
+
+test('check lastBuild get updated', async () => {
+  vi.mock('node:fs', async () => {
+    return {
+      readFile: vi.fn().mockImplementation(() => '[]'),
+      writeFile: vi.fn().mockImplementation(() => Promise.resolve()),
+      existsSync: vi.fn().mockImplementation(() => true),
+    };
+  });
+
+  const history: History = new History('test');
+
+  await history.addImageBuild('a0', 'b0', 'c0');
+  await history.addImageBuild('a1', 'b1', 'c1');
+
+  expect(history.getLastBuildFor('a0').type).toEqual('b0');
+  expect(history.getLastBuildFor('a0').location).toEqual('c0');
+
+  await history.addImageBuild('a0', 'b0b', 'c0b');
+  await history.addImageBuild('a2', 'b2', 'c2');
+
+  expect(history.getLastBuildFor('a0').type).toEqual('b0b');
+  expect(history.getLastBuildFor('a0').location).toEqual('c0b');
+});

--- a/src/history.ts
+++ b/src/history.ts
@@ -54,9 +54,17 @@ export class History {
   public getLastLocation(): string | undefined {
     if (this.infos.length === 0) {
       return undefined;
-    } else {
-      return this.infos[0].location;
     }
+    return this.infos[0].location;
+  }
+
+  public getLastBuildFor(image: string): { type: string; location: string } | undefined {
+    if (this.infos.length === 0) {
+      return undefined;
+    }
+
+    // returns the details of the last build for this image
+    return this.infos.find((_value, index, info) => info[index].image === image);
   }
 
   public async addImageBuild(image: string, type: string, location: string) {


### PR DESCRIPTION
### What does this PR do?

Now that we clean up after a successful build, there's no way to launch vfkit on the image. This adds a command to bootable images, which tries to launch vfkit against the last disk image build.

### Screenshot / video of UI

<img width="938" alt="Screenshot 2024-01-24 at 11 28 00 AM" src="https://github.com/containers/podman-desktop-extension-bootc/assets/19958075/b4bcda24-a4eb-4452-b483-2ef302914256">

### What issues does this PR fix or reference?

Fixes part of #18.

### How to test this PR?

Launch the action on a bootable container that you haven't built before (it fails), then build an image and retry.