### PR TITLE
feat: check for rootful before doing command

### DIFF
--- a/src/machine-utils.spec.ts
+++ b/src/machine-utils.spec.ts
@@ -1,0 +1,86 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { expect, test, vi } from 'vitest';
+import * as extensionApi from '@podman-desktop/api';
+import type { Configuration } from '@podman-desktop/api';
+import * as machineUtils from './machine-utils';
+import * as fs from 'node:fs';
+
+const config: Configuration = {
+  get: () => {
+    // not implemented
+  },
+  has: () => true,
+  update: vi.fn(),
+};
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    configuration: {
+      getConfiguration: () => config,
+      onDidChangeConfiguration: () => {
+        return {
+          dispose: vi.fn(),
+        };
+      },
+    },
+    process: {
+      exec: vi.fn(),
+    },
+  };
+});
+
+test('Check isPodmanMachineRootful functionality', async () => {
+  const fakeMachineInfoJSON = {
+    Host: {
+      Arch: 'amd64',
+      CurrentMachine: '',
+      DefaultMachine: '',
+      EventsDir: 'dir1',
+      MachineConfigDir: 'dir2',
+      MachineImageDir: 'dir3',
+      MachineState: '',
+      NumberOfMachines: 5,
+      OS: 'windows',
+      VMType: 'wsl',
+    },
+  };
+
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>(resolve => {
+        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
+      }),
+  );
+
+  // Mock existsSync to return true (the "fake" file is there)
+  vi.mock('node:fs');
+  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
+    return true;
+  });
+
+  // Mock the readFile function to return the "fake" file with rootful being true
+  const spyReadFile = vi.spyOn(fs.promises, 'readFile');
+
+  // Mock reading the file to have Rootful as true
+  spyReadFile.mockResolvedValue(JSON.stringify({ Rootful: true }));
+  await expect(machineUtils.isPodmanMachineRootful()).resolves.toBe(true);
+});

--- a/src/machine-utils.ts
+++ b/src/machine-utils.ts
@@ -1,0 +1,92 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as extensionApi from '@podman-desktop/api';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+
+// Async function to get machine information in JSON format
+async function getMachineInfo() {
+  const { stdout: machineInfoJson } = await extensionApi.process.exec(getPodmanCli(), [
+    'machine',
+    'info',
+    '--format',
+    'json',
+  ]);
+  return JSON.parse(machineInfoJson);
+}
+
+// Read the machine configuration and error out if we are uanble to read it.
+async function readMachineConfig(machineConfigDir: string, currentMachine: string) {
+  const filepath = path.join(machineConfigDir, `${currentMachine}.json`);
+
+  // Check if the file exists before reading it
+  if (!fs.existsSync(filepath)) {
+    throw new Error(`Machine config file ${filepath} does not exist.`);
+  }
+
+  const machineConfigJson = await fs.promises.readFile(filepath, 'utf8');
+  return JSON.parse(machineConfigJson);
+}
+
+// Check if the current podman machine is rootful
+export async function isPodmanMachineRootful() {
+  try {
+    const machineInfo = await getMachineInfo();
+    const machineConfig = await readMachineConfig(machineInfo.Host.MachineConfigDir, machineInfo.Host.CurrentMachine);
+
+    if (machineConfig.Rootful !== undefined) {
+      // Make sure we convert to boolean in case the value is "true", not true.
+      return Boolean(machineConfig.Rootful);
+    } else {
+      console.error('No Rootful key found in machine config file, there should be one.');
+      return false;
+    }
+  } catch (error) {
+    console.error('Error when checking rootful machine status:', error);
+    return false; // Ensure function returns a boolean even in case of error
+  }
+}
+
+// Below functions are borrowed from the podman extension
+function getPodmanCli(): string {
+  const customBinaryPath = getCustomBinaryPath();
+  if (customBinaryPath) {
+    return customBinaryPath;
+  }
+
+  if (isWindows()) {
+    return 'podman.exe';
+  }
+  return 'podman';
+}
+
+function getCustomBinaryPath(): string | undefined {
+  return extensionApi.configuration.getConfiguration('podman').get('binary.path');
+}
+
+const windows = os.platform() === 'win32';
+export function isWindows(): boolean {
+  return windows;
+}
+
+const linux = os.platform() === 'linux';
+export function isLinux(): boolean {
+  return linux;
+}


### PR DESCRIPTION
feat: check for rootful before doing command

### What does this PR do?

* Makes sure that the podman machine is actually rootful before
  continuing
* Checks via the podman machine info json for rootful status.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/containers/podman-desktop-extension-bootc/assets/6422176/d961aa94-0b29-45b6-880e-8b5703471d5c


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/17

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Start a podman machine as rootless
2. See the error
3. Create another machine thats rootful
4. No error
