### PR TITLE
feat: add header to build logs

### DIFF
--- a/src/build-disk-image.ts
+++ b/src/build-disk-image.ts
@@ -97,6 +97,10 @@ export async function buildDiskImage(imageData: unknown, history: History) {
       let successful: boolean;
       let errorMessage: string;
       let logData: string = 'Build Image Log --------\n';
+      logData += 'Image:  ' + image.name + '\n';
+      logData += 'Type:   ' + selectedType + '\n';
+      logData += 'Folder: ' + selectedFolder + '\n';
+      logData += '----------\n';
 
       // Create log folder
       if (!fs.existsSync(selectedFolder)) {
@@ -117,6 +121,8 @@ export async function buildDiskImage(imageData: unknown, history: History) {
         selectedFolder,
         imagePath,
       );
+      logData += JSON.stringify(buildImageContainer, undefined, 2);
+      logData += '\n----------\n';
 
       try {
         // Step 1. Pull bootcImageBuilder


### PR DESCRIPTION
### What does this PR do?

Adds a header to build logs so that you can see what version of the image builder was used and what the container args are.

### Screenshot / video of UI

```
Build Image Log --------
Image:  quay.io/deboer/bootc
Type:   raw
Folder: /Users/deboer/bootc
----------
{
  "name": "bootc-bootc-image-builder",
  "Image": "quay.io/centos-bootc/bootc-image-builder:latest-1705709685",
  "Tty": true,
  "HostConfig": {
    "Privileged": true,
    "SecurityOpt": [
      "label=type:unconfined_t"
    ],
    "Binds": [
      "/Users/deboer/bootc:/tmp/"
    ]
  },
  "Labels": {
    "bootc.image.builder": "true",
    "bootc.build.image.location": "/Users/deboer/bootc/image/disk.raw",
    "bootc.build.type": "ami"
  },
  "Cmd": [
    "quay.io/deboer/bootc",
    "--type",
    "ami",
    "--output",
    "/tmp/"
  ]
}
----------
```

### What issues does this PR fix or reference?

Fixes #85.

### How to test this PR?

Do a build, look at the log.