### PR TITLE
fix: change output folder

### DIFF
--- a/src/build-disk-image.spec.ts
+++ b/src/build-disk-image.spec.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { createBuilderImageOptions } from './build-disk-image';
+import { bootcImageBuilderName } from './constants';
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    env: {
+      createTelemetryLogger: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('check image builder options', async () => {
+  const image = 'test-image';
+  const type = 'iso';
+  const name = 'my-image';
+  const outputFolder = '/output-folder';
+  const imagePath = '/output-folder/image-path';
+  const options = createBuilderImageOptions(name, image, type, outputFolder, imagePath);
+
+  expect(options).toBeDefined();
+  expect(options.name).toEqual(name);
+  expect(options.Image).toEqual(bootcImageBuilderName);
+  expect(options.HostConfig.Binds[0]).toEqual(outputFolder + ':/output/');
+  expect(options.Cmd).toEqual([image, '--type', type, '--output', '/output/']);
+});

--- a/src/build-disk-image.ts
+++ b/src/build-disk-image.ts
@@ -218,7 +218,7 @@ async function logContainer(image, containerId: string, progress, callback: (dat
 }
 
 // Create builder options for the "bootc-image-builder" container
-function createBuilderImageOptions(
+export function createBuilderImageOptions(
   name: string,
   image: string,
   type: string,

--- a/src/build-disk-image.ts
+++ b/src/build-disk-image.ts
@@ -231,7 +231,7 @@ function createBuilderImageOptions(
     type = 'ami';
   }
 
-  // Create the image options for the "bootc-imge-builder" container
+  // Create the image options for the "bootc-image-builder" container
   const options: ContainerCreateOptions = {
     name: name,
     Image: bootcImageBuilderName,
@@ -239,7 +239,7 @@ function createBuilderImageOptions(
     HostConfig: {
       Privileged: true,
       SecurityOpt: ['label=type:unconfined_t'],
-      Binds: [folder + ':/tmp/'],
+      Binds: [folder + ':/output/'],
     },
 
     // Add the appropriate labels for it to appear correctly in the Podman Desktop UI.
@@ -248,7 +248,7 @@ function createBuilderImageOptions(
       'bootc.build.image.location': imagePath,
       'bootc.build.type': type,
     },
-    Cmd: [image, '--type', type, '--output', '/tmp/'],
+    Cmd: [image, '--type', type, '--output', '/output/'],
   };
 
   return options;


### PR DESCRIPTION
### What does this PR do?

Listing as a chore on our end, although I think we're confirming that the image builder really doesn't like writing to /tmp on some machines and that is causing builds to fail (but only when paired with certain output folders).

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #86.

### How to test this PR?

Test any build.