### PR TITLE
chore: CI shouldn't use latest

### DIFF
--- a/.github/workflows/build-next.yaml
+++ b/.github/workflows/build-next.yaml
@@ -58,9 +58,9 @@ jobs:
         id: publish-image
         run: |
           IMAGE_NAME=ghcr.io/${{ github.repository_owner }}/podman-desktop-extension-bootc
-          IMAGE_LATEST=${IMAGE_NAME}:latest
+          IMAGE_NIGHTLY=${IMAGE_NAME}:nightly
           IMAGE_SHA=${IMAGE_NAME}:${GITHUB_SHA}
-          podman build -t $IMAGE_LATEST .
-          podman push $IMAGE_LATEST
-          podman tag $IMAGE_LATEST $IMAGE_SHA
+          podman build -t $IMAGE_NIGHTLY .
+          podman push $IMAGE_NIGHTLY
+          podman tag $IMAGE_NIGHTLY $IMAGE_SHA
           podman push $IMAGE_SHA


### PR DESCRIPTION
### What does this PR do?

Our CI shouldn't push the latest changes on main to :latest, because then anyone who pulls our latest container image will get the latest, unreleased code. Ideally, they should get the 'latest release'.

This changes the CI to push to :nightly. For the record I don't love the term 'nightly' and I don't think it's quite correct, but it is what AI Studio is using and I think it's better to be consistent. :)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #96.

### How to test this PR?

Minor enough change, we can confirm when this PR is merged.