### PR TITLE
chore: remove temporary fix

### DIFF
--- a/src/build-disk-image.ts
+++ b/src/build-disk-image.ts
@@ -241,12 +241,6 @@ export function createBuilderImageOptions(
   folder: string,
   imagePath: string,
 ): ContainerCreateOptions {
-  // TEMPORARY UNTIL PR IS MERGED IN BOOTC-IMAGE-BUILDER
-  // If type is raw, change it to ami
-  if (type === 'raw') {
-    type = 'ami';
-  }
-
   // Create the image options for the "bootc-image-builder" container
   const options: ContainerCreateOptions = {
     name: name,


### PR DESCRIPTION
chore: remove temporary ami fix

### What does this PR do?

The latest release of bootc-image-builder now has raw support.

Remove the temporary fix for "ami" being "raw".

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/106

### How to test this PR?

<!-- Please explain steps to reproduce -->

You'll be able to build raw normally without it appearing as "ami"

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
