### PR TITLE
chore: update release version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,30 +45,6 @@ jobs:
             echo "githubTag=v$TAG_PATTERN" >> ${GITHUB_OUTPUT}
             echo "bootcExtensionVersion=$TAG_PATTERN" >> ${GITHUB_OUTPUT}
 
-      - name: tag
-        run: |
-          git config --local user.name ${{ github.actor }}
-
-          # Add the new version in package.json file
-          sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ steps.TAG_UTIL.outputs.bootcExtensionVersion }}\",#g" package.json
-          git add package.json
-
-          # commit the changes
-          git commit -m "chore: 🥁 tagging ${{ steps.TAG_UTIL.outputs.githubTag }} 🥳"
-          echo "Tagging with ${{ steps.TAG_UTIL.outputs.githubTag }}"
-          git tag ${{ steps.TAG_UTIL.outputs.githubTag }}
-          git push origin ${{ steps.TAG_UTIL.outputs.githubTag }}
-      - name: Create Release
-        id: create_release
-        uses: ncipollo/release-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag: ${{ steps.TAG_UTIL.outputs.githubTag }}
-          name: ${{ steps.TAG_UTIL.outputs.githubTag }}
-          draft: true
-          prerelease: true
-
       - name: Create the PR to bump the version in the main branch (only if we're tagging from main branch)
         if: ${{ github.event.inputs.branch == 'main' }}
         run: |
@@ -93,6 +69,31 @@ jobs:
           gh pr merge "${pullRequestUrl}" --auto --rebase
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: tag
+        run: |
+          git config --local user.name ${{ github.actor }}
+
+          # Add the new version in package.json file
+          sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ steps.TAG_UTIL.outputs.bootcExtensionVersion }}\",#g" package.json
+          git add package.json
+
+          # commit the changes
+          git commit -m "chore: 🥁 tagging ${{ steps.TAG_UTIL.outputs.githubTag }} 🥳"
+          echo "Tagging with ${{ steps.TAG_UTIL.outputs.githubTag }}"
+          git tag ${{ steps.TAG_UTIL.outputs.githubTag }}
+          git push origin ${{ steps.TAG_UTIL.outputs.githubTag }}
+
+      - name: Create Release
+        id: create_release
+        uses: ncipollo/release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: ${{ steps.TAG_UTIL.outputs.githubTag }}
+          name: ${{ steps.TAG_UTIL.outputs.githubTag }}
+          draft: true
+          prerelease: true
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
### What does this PR do?

The 'tag' release job was setting the correct version in package.json, then bumping it up to create a PR and doing the build, which means the output container has the bumped version and not the release version.

Looked at other options, but the tasks don't appear to depend on each other so I'm just swapping the order.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #116.

### How to test this PR?

Just logic review, till need to wait for next release.