### PR TITLE
fix: change name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bootc-extension",
+  "name": "bootc",
   "displayName": "Bootable Container",
   "description": "Support for bootable OS containers (bootc) and generating disk images",
   "version": "0.2.0-next",


### PR DESCRIPTION
### What does this PR do?
bootc extension is published as `redhat.bootc` in the catalog so it should match the name of the package.json as well
or we change the catalog to use `redhat.bootc-extension`

so when installing the extension we're not finding the right extension after so some buttons are not replaced/ arestill in progress/etc

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/5759

### How to test this PR?

<!-- Please explain steps to reproduce -->
