### PR TITLE
fix: pick unused container name

### DIFF
--- a/src/build-disk-image.spec.ts
+++ b/src/build-disk-image.spec.ts
@@ -43,7 +43,7 @@ test('check image builder options', async () => {
   const name = 'my-image';
   const outputFolder = '/output-folder';
   const imagePath = '/output-folder/image-path';
-  const options = await createBuilderImageOptions(name, image, type, outputFolder, imagePath);
+  const options = createBuilderImageOptions(name, image, type, outputFolder, imagePath);
 
   expect(options).toBeDefined();
   expect(options.name).toEqual(name);

--- a/src/build-disk-image.spec.ts
+++ b/src/build-disk-image.spec.ts
@@ -17,13 +17,18 @@
  ***********************************************************************/
 
 import { beforeEach, expect, test, vi } from 'vitest';
-import { createBuilderImageOptions } from './build-disk-image';
+import { createBuilderImageOptions, getUnusedName } from './build-disk-image';
 import { bootcImageBuilderName } from './constants';
+import type { ContainerInfo } from '@podman-desktop/api';
+import { containerEngine } from '@podman-desktop/api';
 
 vi.mock('@podman-desktop/api', async () => {
   return {
     env: {
       createTelemetryLogger: vi.fn(),
+    },
+    containerEngine: {
+      listContainers: vi.fn().mockReturnValue([]),
     },
   };
 });
@@ -38,11 +43,30 @@ test('check image builder options', async () => {
   const name = 'my-image';
   const outputFolder = '/output-folder';
   const imagePath = '/output-folder/image-path';
-  const options = createBuilderImageOptions(name, image, type, outputFolder, imagePath);
+  const options = await createBuilderImageOptions(name, image, type, outputFolder, imagePath);
 
   expect(options).toBeDefined();
   expect(options.name).toEqual(name);
   expect(options.Image).toEqual(bootcImageBuilderName);
   expect(options.HostConfig.Binds[0]).toEqual(outputFolder + ':/output/');
   expect(options.Cmd).toEqual([image, '--type', type, '--output', '/output/']);
+});
+
+test('check we pick unused container name', async () => {
+  const basename = 'test';
+  let name = await getUnusedName(basename);
+  expect(name).toEqual(basename);
+
+  vi.spyOn(containerEngine, 'listContainers').mockReturnValue([{ Names: ['test'] }] as unknown as Promise<
+    ContainerInfo[]
+  >);
+  name = await getUnusedName(basename);
+  expect(name).toEqual(basename + '-2');
+
+  vi.spyOn(containerEngine, 'listContainers').mockReturnValue([
+    { Names: ['test'] },
+    { Names: ['/test-2'] },
+  ] as unknown as Promise<ContainerInfo[]>);
+  name = await getUnusedName(basename);
+  expect(name).toEqual(basename + '-3');
 });

--- a/src/build-disk-image.ts
+++ b/src/build-disk-image.ts
@@ -130,8 +130,9 @@ export async function buildDiskImage(imageData: unknown, history: History) {
       // Preliminary Step 0. Create the "bootc-image-builder" container
       // options that we will use to build the image. This will help with debugging
       // as well as making sure we delete the previous build, etc.
-      const buildImageContainer = await createBuilderImageOptions(
-        buildContainerName,
+      const containerName = await getUnusedName(buildContainerName);
+      const buildImageContainer = createBuilderImageOptions(
+        containerName,
         image.name + ':' + image.tag,
         selectedType,
         selectedFolder,
@@ -256,16 +257,16 @@ export async function getUnusedName(name: string): Promise<string> {
 }
 
 // Create builder options for the "bootc-image-builder" container
-export async function createBuilderImageOptions(
+export function createBuilderImageOptions(
   name: string,
   image: string,
   type: string,
   folder: string,
   imagePath: string,
-): Promise<ContainerCreateOptions> {
+): ContainerCreateOptions {
   // Create the image options for the "bootc-image-builder" container
   const options: ContainerCreateOptions = {
-    name: await getUnusedName(name),
+    name: name,
     Image: bootcImageBuilderName,
     Tty: true,
     HostConfig: {


### PR DESCRIPTION
### What does this PR do?

Make sure we pick an unused container name so that it's possible to kick off multiple builds at the same time.

Note that there are still two theoretical places this could still fail due to the delay between when you kick off the task and we check for conflicts vs when the container gets created: the first time you ever run (if the bootc builder image takes time to pull down) and if you're super-fast and run the action twice before the container engine can create a container and register back in Podman Desktop. The first seems very unlikely that someone would try, and the second I couldn't even reproduce when trying.

### Screenshot / video of UI

<img width="604" alt="Screenshot 2024-02-05 at 8 25 41 AM" src="https://github.com/containers/podman-desktop-extension-bootc/assets/19958075/6a9d6c6a-67dd-4ee1-aaee-58e44fe589f2">

### What issues does this PR fix or reference?

Fixes #103.

### How to test this PR?

Run two builds at the same time, confirm no name conflict and both images are produced.