### PR TITLE
feat: support new container label

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         {
           "command": "bootc.image.build",
           "title": "Build Disk Image",
-          "when": "ostree.bootable in imageLabelKeys"
+          "when": "ostree.bootable in imageLabelKeys || containers.bootc in imageLabelKeys"
         }
       ]
     },
@@ -45,13 +45,13 @@
       ],
       "icons/image": [
         {
-          "when": "ostree.bootable in imageLabelKeys",
+          "when": "ostree.bootable in imageLabelKeys || containers.bootc in imageLabelKeys",
           "icon": "${bootable-icon}"
         }
       ],
       "badges/image": [
         {
-          "when": "ostree.bootable in imageLabelKeys",
+          "when": "ostree.bootable in imageLabelKeys || containers.bootc in imageLabelKeys",
           "badge": {
             "label": "bootc",
             "color": {


### PR DESCRIPTION
### What does this PR do?

There's an official label for bootable containers: containers.bootc. Adds support for this without removing the previous label for now, so that we don't have any release where only one path works. Once the new label is prevalent we'll remove the old one.

### Screenshot / video of UI

N/A (badge and icon work as before)

### What issues does this PR fix or reference?

First part of #129; will remove old label later.

### How to test this PR?

Manually label an image with containers.bootc and confirm badge, icon, and actions still appear.