### PR TITLE
feat: remove old builder images

### DIFF
--- a/src/build-disk-image.ts
+++ b/src/build-disk-image.ts
@@ -150,6 +150,9 @@ export async function buildDiskImage(imageData: unknown, history: History) {
         progress.report({ increment: 4 });
         await containerUtils.pullImage(buildImageContainer.Image);
 
+        // delete previous copies of the image (in case we have upgraded it)
+        await containerUtils.deleteOldImages(image.engineId, buildImageContainer.Image);
+
         // Step 2. Check if there are any previous builds and remove them
         progress.report({ increment: 5 });
         await containerUtils.removeContainerIfExists(image.engineId, buildImageContainer.name);

--- a/src/container-utils.ts
+++ b/src/container-utils.ts
@@ -106,7 +106,6 @@ export async function deleteOldImages(engineId: string, currentImage: string) {
     }, Promise.resolve());
   } catch (e) {
     console.error(e);
-    throw new Error('There was an error removing the container: ' + e);
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds a new function to delete images with a given name that do not have the same tag (nor a second tag; you can tag to keep something). Uses this to look for and clean up any old builder images, so that we'll automatically clean up whenever we pull a new one.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #98.

### How to test this PR?

Pull the 'latest' bootc builder image and then build a new disk image, 'latest' will be deleted since we're using a tagged one.