### PR TITLE
docs: update readme systemd files

### DIFF
--- a/docs/containerfile_guide.md
+++ b/docs/containerfile_guide.md
@@ -120,12 +120,8 @@ FROM quay.io/centos-bootc/fedora-bootc:eln
 # Add the systemd service
 ADD helloworld.service /usr/lib/systemd/system/helloworld.service
 
-# Equivilant "systemctl enable helloworld"
-# NOTE: Currently have to symlink until systemctl enable
-# functionality works in the future
-RUN ln -s \
-/usr/lib/systemd/system/helloworld.service \
-/usr/lib/systemd/system/default.target.wants/helloworld.service
+# Enable the service
+RUN systemctl enable helloworld
 
 # Add the helloworld example
 ADD helloworld.py /usr/bin/helloworld.py

--- a/examples/bootc-helloworld-python-systemd/Containerfile
+++ b/examples/bootc-helloworld-python-systemd/Containerfile
@@ -3,11 +3,8 @@ FROM quay.io/centos-bootc/fedora-bootc:eln
 # Add the systemd service
 ADD helloworld.service /usr/lib/systemd/system/helloworld.service
 
-# Equivalent "systemctl enable helloworld"
-# will be implemented in the future
-RUN ln -s \
-/usr/lib/systemd/system/helloworld.service \
-/usr/lib/systemd/system/default.target.wants/helloworld.service
+# Enable the service
+RUN systemctl enable helloworld
 
 # Add the helloworld example
 ADD helloworld.py /usr/bin/helloworld.py


### PR DESCRIPTION
docs: update readme systemd files

### What does this PR do?

The centos bootc image now allows using `systemctl enable`

See: https://github.com/CentOS/centos-bootc/issues/167

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
