### PR TITLE
feat: multi-arch support

### DIFF
--- a/src/build-disk-image.spec.ts
+++ b/src/build-disk-image.spec.ts
@@ -40,16 +40,17 @@ beforeEach(() => {
 test('check image builder options', async () => {
   const image = 'test-image';
   const type = 'iso';
+  const arch = 'amd';
   const name = 'my-image';
   const outputFolder = '/output-folder';
   const imagePath = '/output-folder/image-path';
-  const options = createBuilderImageOptions(name, image, type, outputFolder, imagePath);
+  const options = createBuilderImageOptions(name, image, type, arch, outputFolder, imagePath);
 
   expect(options).toBeDefined();
   expect(options.name).toEqual(name);
   expect(options.Image).toEqual(bootcImageBuilderName);
   expect(options.HostConfig.Binds[0]).toEqual(outputFolder + ':/output/');
-  expect(options.Cmd).toEqual([image, '--type', type, '--output', '/output/']);
+  expect(options.Cmd).toEqual([image, '--type', type, '--target-arch', arch, '--output', '/output/']);
 });
 
 test('check we pick unused container name', async () => {

--- a/src/build-disk-image.ts
+++ b/src/build-disk-image.ts
@@ -69,8 +69,8 @@ export async function buildDiskImage(imageData: unknown, history: History) {
 
   const selectionArch = await extensionApi.window.showQuickPick(
     [
-      { label: 'ARM®', detail: 'ARM® 64 / aarch64 (arm64)', format: 'arm64' },
-      { label: 'AMD64', detail: 'AMD 64 / x86-64 (amd64)', format: 'amd64' },
+      { label: 'ARM64', detail: 'ARM® aarch64 systems', arch: 'arm64' },
+      { label: 'AMD64', detail: 'Intel and AMD x86_64 systems', arch: 'amd64' },
     ],
     {
       title: 'Select the architecture',
@@ -81,7 +81,7 @@ export async function buildDiskImage(imageData: unknown, history: History) {
     telemetryLogger.logUsage('buildDiskImage', telemetryData);
     return;
   }
-  const selectedArch = selectionArch.format;
+  const selectedArch = selectionArch.arch;
   telemetryData.arch = selectedArch;
 
   const location = history.getLastLocation() || os.homedir();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,4 +18,4 @@
 
 // Image related
 export const bootcImageBuilderContainerName = '-bootc-image-builder';
-export const bootcImageBuilderName = 'quay.io/centos-bootc/bootc-image-builder:latest-1706124830';
+export const bootcImageBuilderName = 'quay.io/centos-bootc/bootc-image-builder:latest-1708009307';


### PR DESCRIPTION
### What does this PR do?

Step up to the latest image builder, and adds support for the new --target-arch parameter, which supports building arm64 and amd64 disk images.

### Screenshot / video of UI

<img width="697" alt="Screenshot 2024-02-15 at 4 52 25 PM" src="https://github.com/containers/podman-desktop-extension-bootc/assets/19958075/4ee921d7-13c4-4249-a6a7-b1bf74d0e9ce">

### What issues does this PR fix or reference?

Fixes #28.

### How to test this PR?

Build an image with both architectures.