### PR TITLE
chore: end dialogs and period

### DIFF
--- a/src/build-disk-image.ts
+++ b/src/build-disk-image.ts
@@ -222,13 +222,14 @@ export async function buildDiskImage(imageData: unknown, history: History) {
         await extensionApi.window.showInformationMessage(
           `Success! Your Bootable OS Container has been succesfully created to ${imagePath}`,
           'OK',
-          'Cancel',
         );
       } else {
+        if (!errorMessage.endsWith('.')) {
+          errorMessage += '.';
+        }
         await extensionApi.window.showErrorMessage(
-          `There was an error building the image: ${errorMessage}. Check logs at ${logPath}`,
+          `There was an error building the image: ${errorMessage} Check logs at ${logPath}`,
           'OK',
-          'Cancel',
         );
       }
     },


### PR DESCRIPTION
### What does this PR do?

The success or failure dialogs at the end have OK or Cancel buttons, but there is no difference between the two; they should only have an OK button.

The error message usually has a period, leading to a double period when failures happen. Add a check to make sure there is only one period.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Just do a successful/unsuccessful build and look at the dialogs at the end.