### PR TITLE
feat: refactor of build logic / more history info / quickpicks

### DIFF
--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -21,6 +21,7 @@ import * as extensionApi from '@podman-desktop/api';
 import { launchVFKit } from './launch-vfkit';
 import { buildDiskImage } from './build-disk-image';
 import { History } from './history';
+import { bootcBuildOptionSelection } from './quickpicks';
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   console.log('starting bootc extension');
@@ -32,9 +33,19 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     extensionApi.commands.registerCommand('bootc.vfkit', async container => {
       await launchVFKit(container);
     }),
-
     extensionApi.commands.registerCommand('bootc.image.build', async image => {
-      await buildDiskImage(image, history);
+      const selections = await bootcBuildOptionSelection(history);
+      await buildDiskImage(
+        {
+          name: image.name,
+          tag: image.tag,
+          engineId: image.engineId,
+          type: selections.type,
+          folder: selections.folder,
+          arch: selections.arch,
+        },
+        history,
+      );
     }),
   );
 }

--- a/packages/backend/src/history.spec.ts
+++ b/packages/backend/src/history.spec.ts
@@ -17,44 +17,87 @@
  ***********************************************************************/
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { History } from './history';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-test('check simple add and get', async () => {
-  vi.mock('node:fs', async () => {
-    return {
-      readFile: vi.fn().mockImplementation(() => '[]'),
-      writeFile: vi.fn().mockImplementation(() => Promise.resolve()),
-      existsSync: vi.fn().mockImplementation(() => true),
-    };
+describe('History class tests', () => {
+  test('check simple add and get', async () => {
+    vi.mock('node:fs', async () => {
+      return {
+        readFile: vi.fn().mockImplementation(() => '[]'),
+        writeFile: vi.fn().mockImplementation(() => Promise.resolve()),
+        existsSync: vi.fn().mockImplementation(() => true),
+        mkdir: vi.fn().mockImplementation(() => Promise.resolve()),
+      };
+    });
+
+    const tmpDir = os.tmpdir();
+    const tmpFilePath = path.join(tmpDir, `tempfile-${Date.now()}`);
+    const history = new History(tmpFilePath);
+
+    await history.addOrUpdateBuildInfo({
+      name: 'exampleName',
+      tag: 'exampleTag',
+      engineId: 'exampleEngineId',
+      type: 'exampleType',
+      folder: 'exampleFolder',
+      arch: 'exampleArch',
+      status: 'success', // Use appropriate status from BootcBuildStatus
+    });
+
+    expect(history.getLastFolder()).toEqual('exampleFolder');
   });
 
-  const history: History = new History('test');
+  test('check get returns latest after multiple adds', async () => {
+    vi.mock('node:fs', async () => {
+      return {
+        readFile: vi.fn().mockImplementation(() => '[]'),
+        writeFile: vi.fn().mockImplementation(() => Promise.resolve()),
+        existsSync: vi.fn().mockImplementation(() => true),
+        mkdir: vi.fn().mockImplementation(() => Promise.resolve()),
+      };
+    });
 
-  await history.addImageBuild('a', 'b', 'c');
+    const tmpDir = os.tmpdir();
+    const tmpFilePath = path.join(tmpDir, `tempfile-${Date.now()}`);
+    const history = new History(tmpFilePath);
 
-  expect(history.getLastLocation()).toEqual('c');
-});
+    await history.addOrUpdateBuildInfo({
+      name: 'exampleName0',
+      tag: 'exampleTag0',
+      engineId: 'exampleEngineId0',
+      type: 'exampleType0',
+      folder: 'exampleFolder0',
+      arch: 'exampleArch0',
+      status: 'success',
+    });
 
-test('check get returns latest after multiple adds', async () => {
-  vi.mock('node:fs', async () => {
-    return {
-      readFile: vi.fn().mockImplementation(() => '[]'),
-      writeFile: vi.fn().mockImplementation(() => Promise.resolve()),
-      existsSync: vi.fn().mockImplementation(() => true),
-    };
+    await history.addOrUpdateBuildInfo({
+      name: 'exampleName1',
+      tag: 'exampleTag1',
+      engineId: 'exampleEngineId1',
+      type: 'exampleType1',
+      folder: 'exampleFolder1',
+      arch: 'exampleArch1',
+      status: 'success',
+    });
+
+    await history.addOrUpdateBuildInfo({
+      name: 'exampleName2',
+      tag: 'exampleTag2',
+      engineId: 'exampleEngineId2',
+      type: 'exampleType2',
+      folder: 'exampleFolder2',
+      arch: 'exampleArch2',
+      status: 'success',
+    });
+
+    expect(history.getLastFolder()).toEqual('exampleFolder2');
   });
-
-  const history: History = new History('test');
-
-  await history.addImageBuild('a0', 'b0', 'c0');
-  await history.addImageBuild('a1', 'b1', 'c1');
-  await history.addImageBuild('a2', 'b2', 'c2');
-
-  expect(history.getLastLocation()).toEqual('c2');
 });

--- a/packages/backend/src/quickpicks.spec.ts
+++ b/packages/backend/src/quickpicks.spec.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect, vi, beforeAll } from 'vitest';
+import { bootcBuildOptionSelection } from './quickpicks'; // Update with the actual new file name
+import * as extensionApi from '@podman-desktop/api';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { History } from './history'; // Assuming this is the correct path
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    window: {
+      showQuickPick: vi.fn(),
+      showInputBox: vi.fn(),
+    },
+  };
+});
+
+// "Fake" the history file
+vi.mock('node:fs', async () => {
+  return {
+    existsSync: vi.fn().mockImplementation(() => true),
+    readFile: vi.fn().mockImplementation(() => '[]'),
+    writeFile: vi.fn().mockImplementation(() => Promise.resolve()),
+    mkdir: vi.fn().mockImplementation(() => Promise.resolve()),
+  };
+});
+
+beforeAll(async () => {});
+
+describe('bootcBuildOptionSelection', () => {
+  test('Check that selections are shown correctly for the first pick (selecting images)', async () => {
+    // Before all, add an example "entry" to the history
+    // so we can test the getLastFolder function
+
+    // Create a temporary file to use for the example history
+    const tempDir = os.tmpdir();
+    const tempFilePath = path.join(tempDir, `tempfile-${Date.now()}`);
+
+    const history = new History(tempFilePath);
+    await history.addOrUpdateBuildInfo({
+      name: 'exampleName',
+      tag: 'exampleTag',
+      engineId: 'exampleEngineId',
+      type: 'exampleType',
+      folder: '/example/fake/folder',
+      arch: 'exampleArch',
+      status: 'success',
+    });
+
+    const showQuickPickMock = vi.spyOn(extensionApi.window, 'showQuickPick');
+
+    // First call to showQuickPick (disk image type selection)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    showQuickPickMock.mockResolvedValueOnce({ label: 'QCOW2', detail: 'QEMU image (.qcow2)', format: 'qcow2' } as any);
+
+    // Second call to showQuickPick (architecture selection)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    showQuickPickMock.mockResolvedValueOnce({ label: 'ARM64', detail: 'ARM® aarch64 systems', arch: 'arm64' } as any);
+
+    // Third call to showInputBox (folder selection)
+    vi.spyOn(extensionApi.window, 'showInputBox').mockResolvedValueOnce('/path/to/fake/storage');
+
+    // This function is asynchronous, so make sure to await it
+    await bootcBuildOptionSelection(history);
+
+    // Check the first call for selecting the disk image type
+    expect(showQuickPickMock).toHaveBeenNthCalledWith(
+      1, // This indicates the first call
+      [
+        { label: 'QCOW2', detail: 'QEMU image (.qcow2)', format: 'qcow2' },
+        { label: 'AMI', detail: 'Amazon Machine Image (.ami)', format: 'ami' },
+        { label: 'RAW', detail: 'Raw image (.raw) with an MBR or GPT partition table', format: 'raw' },
+        { label: 'ISO', detail: 'ISO standard disk image (.iso) for flashing media and using EFI', format: 'iso' },
+      ],
+      {
+        title: 'Select the type of disk image to create',
+      },
+    );
+
+    // Check the second call for selecting the architecture
+    expect(showQuickPickMock).toHaveBeenNthCalledWith(
+      2, // This indicates the second call
+      [
+        { label: 'ARM64', detail: 'ARM® aarch64 systems', arch: 'arm64' },
+        { label: 'AMD64', detail: 'Intel and AMD x86_64 systems', arch: 'amd64' },
+      ],
+      {
+        title: 'Select the architecture',
+      },
+    );
+
+    // Check the third call for selecting the folder
+    expect(extensionApi.window.showInputBox).toHaveBeenCalledWith({
+      prompt: 'Select the folder to generate disk qcow2 into',
+      value: '/example/fake/folder',
+      ignoreFocusOut: true,
+    });
+  });
+});

--- a/packages/backend/src/quickpicks.ts
+++ b/packages/backend/src/quickpicks.ts
@@ -1,0 +1,72 @@
+import type { History } from './history';
+import * as extensionApi from '@podman-desktop/api';
+import * as os from 'node:os';
+import { resolve } from 'node:path';
+
+export interface BootcBuildOptionSelection {
+  type: string;
+  folder: string;
+  path: string;
+  arch: string;
+}
+
+export async function bootcBuildOptionSelection(history: History): Promise<BootcBuildOptionSelection | undefined> {
+  const selection = await extensionApi.window.showQuickPick(
+    [
+      { label: 'QCOW2', detail: 'QEMU image (.qcow2)', format: 'qcow2' },
+      { label: 'AMI', detail: 'Amazon Machine Image (.ami)', format: 'ami' },
+      { label: 'RAW', detail: 'Raw image (.raw) with an MBR or GPT partition table', format: 'raw' },
+      { label: 'ISO', detail: 'ISO standard disk image (.iso) for flashing media and using EFI', format: 'iso' },
+    ],
+    {
+      title: 'Select the type of disk image to create',
+    },
+  );
+
+  if (!selection) {
+    return;
+  }
+
+  const selectedType = selection.format;
+
+  const selectionArch = await extensionApi.window.showQuickPick(
+    [
+      { label: 'ARM64', detail: 'ARM® aarch64 systems', arch: 'arm64' },
+      { label: 'AMD64', detail: 'Intel and AMD x86_64 systems', arch: 'amd64' },
+    ],
+    {
+      title: 'Select the architecture',
+    },
+  );
+  if (!selectionArch) {
+    return;
+  }
+  const selectedArch = selectionArch.arch;
+
+  const location = history.getLastFolder() ?? os.homedir();
+  const selectedFolder = await extensionApi.window.showInputBox({
+    prompt: `Select the folder to generate disk ${selectedType} into`,
+    value: location,
+    ignoreFocusOut: true,
+  });
+
+  if (!selectedFolder) {
+    return;
+  }
+
+  const imageNameMap = {
+    qcow2: 'qcow2/disk.qcow2',
+    ami: 'image/disk.raw',
+    raw: 'image/disk.raw',
+    iso: 'bootiso/disk.iso',
+  };
+
+  const imagePath = resolve(selectedFolder, imageNameMap[selectedType]);
+
+  return {
+    type: selectedType,
+    folder: selectedFolder,
+    path: imagePath,
+    arch: selectedArch,
+  };
+}

--- a/packages/shared/src/models/bootc.ts
+++ b/packages/shared/src/models/bootc.ts
@@ -1,0 +1,13 @@
+export interface BootcBuildInfo {
+  name: string;
+  tag: string;
+  engineId: string;
+  type: string;
+  folder: string;
+  arch: string;
+  status?: BootcBuildStatus;
+  timestamp?: string;
+  buildContainerId?: string; // The image ID that is used to build the image
+}
+
+export type BootcBuildStatus = 'running' | 'creating' | 'success' | 'error' | 'lost' | 'deleting';

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "strict": true,
+    "resolveJsonModule": true,
+    "preserveValueImports": false,
+    "baseUrl": ".",
+    "allowJs": true,
+    "checkJs": true,
+  },
+  "include": [
+    "src/**/*.d.ts",
+    "src/**/*.ts",
+    "src/**/*.js",
+    "types/*.d.ts",
+    "../../types/**/*.d.ts",
+  ]
+}

--- a/packages/shared/vite.config.js
+++ b/packages/shared/vite.config.js
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import {join} from 'path';
+import {builtinModules} from 'module';
+
+const PACKAGE_ROOT = __dirname;
+
+/**
+ * @type {import('vite').UserConfig}
+ * @see https://vitejs.dev/config/
+ */
+const config = {
+  mode: process.env.MODE,
+  root: PACKAGE_ROOT,
+  envDir: process.cwd(),
+  resolve: {
+    alias: {
+      '/@/': join(PACKAGE_ROOT, 'src') + '/',
+    },
+  },
+  build: {
+    sourcemap: 'inline',
+    target: 'esnext',
+    outDir: 'dist',
+    assetsDir: '.',
+    minify: process.env.MODE === 'production' ? 'esbuild' : false,
+    lib: {
+      entry: 'src/extension.ts',
+      formats: ['cjs'],
+    },
+    rollupOptions: {
+      external: [
+        '@podman-desktop/api',
+        ...builtinModules.flatMap(p => [p, `node:${p}`]),
+      ],
+      output: {
+        entryFileNames: '[name].js',
+      },
+    },
+    emptyOutDir: true,
+    reportCompressedSize: false,
+  },
+};
+
+export default config;

--- a/packages/shared/vitest.config.js
+++ b/packages/shared/vitest.config.js
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import path from 'node:path';
+import { join } from 'path';
+
+const PACKAGE_ROOT = __dirname;
+
+const config = {
+  test: {
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)', '../shared/**/*.{test,spec}.?(c|m)[jt]s?(x)']
+  },
+  resolve: {
+    alias: {
+      '@podman-desktop/api': path.resolve(__dirname, '__mocks__/@podman-desktop/api.js'),
+      '/@/': join(PACKAGE_ROOT, 'src') + '/',
+    },
+  },
+};
+
+export default config;


### PR DESCRIPTION
feat: refactor of build logic / more history info / quickpicks

### What does this PR do?

In order to add the "quickpick" logic in a separate file, it was
beneficial to also refactor what history information we also save.

In this PR we:
* Separate the "quickpick" functionality into a separate file, so we may
  use the build disk image function separately
* Additional history information being saved such as build container id,
  timestamp, etc.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, internal only. Build functionality should work as intended.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes #173
Closes #174

### How to test this PR?

<!-- Please explain steps to reproduce -->

Build a disk image, it should continue as normal.

Check:
`~/.local/share/containers/podman-desktop/extensions-storage/redhat.bootc/history.json`
for the 'updated history info'

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
