### PR TITLE
chore: enable prefer nullish for eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,6 +52,7 @@
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/no-misused-promises": "error",
     "@typescript-eslint/prefer-optional-chain": "error",
+    "@typescript-eslint/prefer-nullish-coalescing": "error",
     "no-null/no-null": "error",
 
   /**

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strictNullChecks": true,
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "Node",


### PR DESCRIPTION
chore: enable prefer nullish for eslint

### What does this PR do?

Enables prefer `??` over `||` for eslint

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

run `yarn lint:fix`

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
