### PR TITLE
docs: update docs regarding Linux and 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,13 @@ Disclaimer: This is **EXPERIMENTAL** and all features are subject to change as w
 
 ### Requirement 1. Software and hardware requirements
 
-**Hardware:**
-* macOS Silicon
-* Windows
+**OS:**
 
-Note: Linux not supported, but coming soon (see #93)
+Compatible on Windows, macOS & Linux
 
 **Software:**
-* [Podman Desktop 1.7.0+](https://github.com/containers/podman-desktop)
-* [Podman 4.9.0+](https://github.com/containers/podman) (should be automatically installed by Podman Desktop already)
+* [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
+* [Podman 5.0.0+](https://github.com/containers/podman)
 
 ### Requirement 2. Rootful mode on Podman Machine
 


### PR DESCRIPTION
docs: update docs regarding Linux and 5.0.0

### What does this PR do?

In order to use this extension, we require 5.0.0 as below that version
is very unstable.

Linux is also now supported with being able to create a rootful Podman Machine
on Podman Desktop.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/93
Closes https://github.com/containers/podman-desktop-extension-bootc/issues/140
Closes https://github.com/containers/podman-desktop-extension-bootc/issues/185

### How to test this PR?

<!-- Please explain steps to reproduce -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
