### PR TITLE
docs: Add more details regarding Linux podman machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ Or set when initially creating a Podman Machine via Podman Desktop:
 
 ![rootful setup](/docs/img/rootful_setup.png)
 
+**Linux users:** 
+
+On Linux, you are unable to create a Podman Machine through the GUI of Podman Desktop, to create a rootful Podman Machine you can run the following commands:
+
+```sh
+podman machine init --rootful
+podman machine start
+```
+
 ## Installation
 
 This extension can be installed through the **Extensions** page of Podman Desktop.


### PR DESCRIPTION
docs: Add more details regarding Linux podman machine

### What does this PR do?

Adds some more details regarding rootful mode on Linux with podman
machine. Since you cannot create the machine through the podman desktop
GUI, you must create it via the command line.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

References #93

### How to test this PR?

<!-- Please explain steps to reproduce -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
