### PR TITLE
docs: Add note regarding arm64 testing using vfkit

### DIFF
--- a/docs/vm_guide.md
+++ b/docs/vm_guide.md
@@ -12,6 +12,8 @@ However, we provide some detailed instructions on how to run this on different o
 
 The easiest solution to run this on macOS is by using [vfkit](https://github.com/crc-org/vfkit) which uses the native Apple hypervisor framework.
 
+NOTE: This will only run NATIVE architecture images. Your image must use the ARM64 output.
+
 ### Installation
 
 This can be installed via:


### PR DESCRIPTION
docs: Add note regarding arm64 testing using vfkit

### What does this PR do?

Adds note regarding applehv only running arm64 images.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

References https://github.com/containers/podman-desktop-extension-bootc/issues/184

### How to test this PR?

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
