### PR TITLE
chore: dynamically write log files

### DIFF
--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -130,6 +130,11 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History): P
       );
       logData += JSON.stringify(buildImageContainer, undefined, 2);
       logData += '\n----------\n';
+      try {
+        fs.writeFileSync(logPath, logData);
+      } catch (e) {
+        // ignore
+      }
 
       if (!buildImageContainer) {
         await extensionApi.window.showErrorMessage('Error creating container options.');
@@ -168,7 +173,11 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History): P
 
         // Step 3.1 Since we have started the container, we can now go get the logs
         await logContainer(build.engineId, containerId, progress, data => {
-          logData += data;
+          try {
+            fs.appendFileSync(logPath, data);
+          } catch (e) {
+            // ignore
+          }
         });
 
         // Step 4. Wait for the container to exit
@@ -204,13 +213,6 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History): P
         console.error(error);
         telemetryData.error = error;
       } finally {
-        // Regardless, write the log file and ignore if we can't even write it.
-        try {
-          fs.writeFileSync(logPath, logData, { flag: 'w' });
-        } catch (e) {
-          // ignore
-        }
-
         // ###########
         // # CLEANUP #
         // ###########

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -131,9 +131,9 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History): P
       logData += JSON.stringify(buildImageContainer, undefined, 2);
       logData += '\n----------\n';
       try {
-        fs.writeFileSync(logPath, logData);
+        await fs.promises.writeFile(logPath, logData);
       } catch (e) {
-        // ignore
+        console.debug('Could not write bootc build log: ', e);
       }
 
       if (!buildImageContainer) {
@@ -172,11 +172,11 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History): P
         await history.addOrUpdateBuildInfo(build);
 
         // Step 3.1 Since we have started the container, we can now go get the logs
-        await logContainer(build.engineId, containerId, progress, data => {
+        await logContainer(build.engineId, containerId, progress, data => async () => {
           try {
-            fs.appendFileSync(logPath, data);
+            await fs.promises.appendFile(logPath, data);
           } catch (e) {
-            // ignore
+            console.debug('Could not write bootc build log: ', e);
           }
         });
 


### PR DESCRIPTION
### What does this PR do?

Write the log files to disk as we get the data, instead of buffering and waiting until the end. This is better for debugging outside of Podman Desktop and will help in the future if we need to show logs in another view.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #78.

### How to test this PR?

Build an image and open image-build.log before it is done.