### PR TITLE
feat: build from local storage

### DIFF
--- a/packages/backend/src/build-disk-image.spec.ts
+++ b/packages/backend/src/build-disk-image.spec.ts
@@ -52,8 +52,9 @@ test('check image builder options', async () => {
   expect(options.HostConfig).toBeDefined();
   if (options.HostConfig?.Binds) {
     expect(options.HostConfig.Binds[0]).toEqual(outputFolder + ':/output/');
+    expect(options.HostConfig.Binds[1]).toEqual('/var/lib/containers/storage:/var/lib/containers/storage');
   }
-  expect(options.Cmd).toEqual([image, '--type', type, '--target-arch', arch, '--output', '/output/']);
+  expect(options.Cmd).toEqual([image, '--type', type, '--target-arch', arch, '--output', '/output/', '--local']);
 });
 
 test('check we pick unused container name', async () => {

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -344,7 +344,7 @@ export function createBuilderImageOptions(
       'bootc.build.image.location': imagePath,
       'bootc.build.type': type,
     },
-    Cmd: [image, '--type', type, '--target-arch', arch, '--output', '/output/','--local'],
+    Cmd: [image, '--type', type, '--target-arch', arch, '--output', '/output/', '--local'],
   };
 
   return options;

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -335,7 +335,7 @@ export function createBuilderImageOptions(
     HostConfig: {
       Privileged: true,
       SecurityOpt: ['label=type:unconfined_t'],
-      Binds: [folder + ':/output/'],
+      Binds: [folder + ':/output/', '/var/lib/containers/storage:/var/lib/containers/storage'],
     },
 
     // Add the appropriate labels for it to appear correctly in the Podman Desktop UI.
@@ -344,7 +344,7 @@ export function createBuilderImageOptions(
       'bootc.build.image.location': imagePath,
       'bootc.build.type': type,
     },
-    Cmd: [image, '--type', type, '--target-arch', arch, '--output', '/output/'],
+    Cmd: [image, '--type', type, '--target-arch', arch, '--output', '/output/','--local'],
   };
 
   return options;

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -18,4 +18,4 @@
 
 // Image related
 export const bootcImageBuilderContainerName = '-bootc-image-builder';
-export const bootcImageBuilderName = 'quay.io/centos-bootc/bootc-image-builder:latest-1708009307';
+export const bootcImageBuilderName = 'quay.io/centos-bootc/bootc-image-builder:latest-1710916056';

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -230,10 +230,6 @@ $: {
                 >.
               </p>
             {/if}
-            <p class="text-gray-300 text-xs pt-1">
-              Note: All images must be pushed to a publically accessible registry in order for our build system to
-              "pull" the images. This is TEMPORARY and local image building will be supported in the future.
-            </p>
           </div>
           <div>
             <label for="path" class="block mb-2 text-sm font-bold text-gray-400">Build output folder</label>


### PR DESCRIPTION
### What does this PR do?

The Bootc image builder added support to build from local storage via https://github.com/osbuild/bootc-image-builder/issues/90.

This updates to the current bootc image builder image, and adds the two new required options:
 - --local, should be temporary/default soon
 - volume mapping to /var/lib/containers/storage

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #178.

### How to test this PR?

Test updated.