### PR TITLE
feat: add vmdk option

### DIFF
--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -67,6 +67,8 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History): P
     imageName = 'image/disk.raw';
   } else if (build.type === 'raw') {
     imageName = 'image/disk.raw';
+  } else if (build.type === 'vmdk') {
+    imageName = 'image/disk.vmdk';
   } else if (build.type === 'iso') {
     imageName = 'bootiso/disk.iso';
   } else {

--- a/packages/backend/src/quickpicks.spec.ts
+++ b/packages/backend/src/quickpicks.spec.ts
@@ -69,6 +69,7 @@ describe('bootcBuildOptionSelection', () => {
         { label: 'QCOW2', detail: 'QEMU image (.qcow2)', format: 'qcow2' },
         { label: 'AMI', detail: 'Amazon Machine Image (.ami)', format: 'ami' },
         { label: 'RAW', detail: 'Raw image (.raw) with an MBR or GPT partition table', format: 'raw' },
+        { label: 'VMDK', detail: 'Virtual Machine Disk image (.vmdk)', format: 'vmdk' },
         { label: 'ISO', detail: 'ISO standard disk image (.iso) for flashing media and using EFI', format: 'iso' },
       ],
       {

--- a/packages/backend/src/quickpicks.ts
+++ b/packages/backend/src/quickpicks.ts
@@ -16,6 +16,7 @@ export async function bootcBuildOptionSelection(history: History): Promise<Bootc
       { label: 'QCOW2', detail: 'QEMU image (.qcow2)', format: 'qcow2' },
       { label: 'AMI', detail: 'Amazon Machine Image (.ami)', format: 'ami' },
       { label: 'RAW', detail: 'Raw image (.raw) with an MBR or GPT partition table', format: 'raw' },
+      { label: 'VMDK', detail: 'Virtual Machine Disk image (.vmdk)', format: 'vmdk' },
       { label: 'ISO', detail: 'ISO standard disk image (.iso) for flashing media and using EFI', format: 'iso' },
     ],
     {
@@ -58,6 +59,7 @@ export async function bootcBuildOptionSelection(history: History): Promise<Bootc
     qcow2: 'qcow2/disk.qcow2',
     ami: 'image/disk.raw',
     raw: 'image/disk.raw',
+    vmdk: 'image/disk.vmdk',
     iso: 'bootiso/disk.iso',
   };
 

--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -135,3 +135,9 @@ test('Render shows correct images and history', async () => {
   // but use isIsnstanceIf for checking
   expect(folder).toBeInstanceOf(HTMLInputElement);
 });
+
+test('Check that VMDK option is there', async () => {
+  await waitRender(Build);
+  const vmdk = screen.getByLabelText('vmdk-select');
+  expect(vmdk).toBeDefined();
+});

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -296,6 +296,22 @@ $: {
                 </label>
               </div>
               <div class="flex items-center mb-3">
+                <label for="vmdk" class="ml-1 flex items-center cursor-pointer">
+                  <input
+                    bind:group="{buildType}"
+                    type="radio"
+                    id="vmdk"
+                    name="format"
+                    value="vmdk"
+                    class="sr-only peer"
+                    aria-label="vmdk-select" />
+                  <div
+                    class="w-4 h-4 rounded-full border-2 border-gray-400 mr-2 peer-checked:border-purple-500 peer-checked:bg-purple-500">
+                  </div>
+                  <span class="text-sm text-white">Virtual Machine Disk image (*.vmdk)</span>
+                </label>
+              </div>
+              <div class="flex items-center mb-3">
                 <label for="ami" class="ml-1 flex items-center cursor-pointer">
                   <input
                     bind:group="{buildType}"


### PR DESCRIPTION
feat: add vmdk option

### What does this PR do?

Adds the VMDK option for buildin.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2024-03-21 at 10 59 50 AM](https://github.com/containers/podman-desktop-extension-bootc/assets/6422176/cbbf3529-6d85-4164-bf65-a32008888b63)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/183

### How to test this PR?

1. Test using the httpd example container
2. Build the vmdk
3. Run in on your favourite vmdk software

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
