### PR TITLE
fix: register webview for disposal

### DIFF
--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -54,6 +54,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
   const panel = extensionApi.window.createWebviewPanel('bootc', 'Bootc', {
     localResourceRoots: [extensionApi.Uri.joinPath(extensionContext.extensionUri, 'media')],
   });
+  extensionContext.subscriptions.push(panel);
 
   const indexHtmlUri = extensionApi.Uri.joinPath(extensionContext.extensionUri, 'media', 'index.html');
   const indexHtmlPath = indexHtmlUri.fsPath;


### PR DESCRIPTION
### What does this PR do?

The webview wasn't registered as a subscription, so it wasn't cleaned up when the extension is stopped.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #227.

### How to test this PR?

Go to Settings > Extensions and stop/start the extension. Prior to the fix the webview would be registered multiple times.