### PR TITLE
nit: Homepage not Dashboard

### DIFF
--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -92,7 +92,7 @@ async function buildBootcImage() {
     bootcClient.buildImage(buildOptions);
 
     // Continue doing listHistoryInfo until the build container name, tag, type and arch show up
-    // this means we can safely exit and see it in the dashboard as it's now in the history / running in the background.
+    // this means we can safely exit and see it in the homepage as it's now in the history / running in the background.
     let timeout = 0;
     const timeoutLimit = 15; // Timeout after 15 seconds. This should be "instantaneous" to the API, but sometimes the API may be slow (reload of the page during `yarn watch`, machine freezes, etc.).
 

--- a/packages/frontend/src/lib/upstream/stores/breadcrumb.ts
+++ b/packages/frontend/src/lib/upstream/stores/breadcrumb.ts
@@ -20,7 +20,7 @@ import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
 import type { TinroBreadcrumb } from 'tinro';
 
-const home = { name: 'Dashboard', path: '/' } as TinroBreadcrumb;
+const home = { name: 'Homepage', path: '/' } as TinroBreadcrumb;
 export const currentPage: Writable<TinroBreadcrumb> = writable(home);
 export const lastPage: Writable<TinroBreadcrumb> = writable(home);
 export const history: Writable<TinroBreadcrumb[]> = writable([home]);


### PR DESCRIPTION
nit: Homepage not Dashboard

### What does this PR do?

Should be Homepage not Dashboard for the breadcrumb / comments

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2024-03-22 at 3 13 45 PM](https://github.com/containers/podman-desktop-extension-bootc/assets/6422176/4ae40fad-5758-475c-bbb2-fec8e7a3e0a8)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

You'll see it say Homepage not Dashboard when clicking on Build.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
