### PR TITLE
nit: fix naming to match extension

### DIFF
--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -20,10 +20,10 @@ onMount(() => {
 });
 </script>
 
-<Route path="/*" breadcrumb="Home" isAppMounted="{isMounted}" let:meta>
+<Route path="/*" breadcrumb="Bootable Containers" isAppMounted="{isMounted}" let:meta>
   <main class="flex flex-col w-screen h-screen overflow-hidden bg-charcoal-700">
     <div class="flex flex-row w-full h-full overflow-hidden">
-      <Route path="/" breadcrumb="Homepage">
+      <Route path="/" breadcrumb="Bootable Containers">
         <Homepage />
       </Route>
       <Route path="/build" breadcrumb="Build">

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -157,7 +157,7 @@ $: {
 }
 </script>
 
-<FormPage title="BootC Image Builder" inProgress="{buildInProgress}" showBreadcrumb="{true}">
+<FormPage title="Build Disk Image" inProgress="{buildInProgress}" showBreadcrumb="{true}">
   <svelte:fragment slot="icon">
     <i class="fas fa-rocket fa-2x" aria-hidden="true"></i>
   </svelte:fragment>

--- a/packages/frontend/src/lib/NoBootcImagesEmptyScreen.spec.ts
+++ b/packages/frontend/src/lib/NoBootcImagesEmptyScreen.spec.ts
@@ -27,6 +27,6 @@ import NoBootcImagesEmptyScreen from './NoBootcImagesEmptyScreen.svelte';
 
 test('Expect empty screen', async () => {
   render(NoBootcImagesEmptyScreen);
-  const noDeployments = screen.getByRole('heading', { name: 'No BootC builds have been created yet' });
+  const noDeployments = screen.getByRole('heading', { name: 'No Bootable Container builds have been created yet' });
   expect(noDeployments).toBeInTheDocument();
 });

--- a/packages/frontend/src/lib/NoBootcImagesEmptyScreen.svelte
+++ b/packages/frontend/src/lib/NoBootcImagesEmptyScreen.svelte
@@ -4,6 +4,6 @@ import { faLayerGroup } from '@fortawesome/free-solid-svg-icons';
 </script>
 
 <EmptyScreen
-  title="No BootC builds have been created yet"
+  title="No Bootable Container builds have been created yet"
   message="Click on 'Build' to start your first build!"
   icon="{faLayerGroup}" />

--- a/packages/frontend/src/lib/upstream/stores/breadcrumb.ts
+++ b/packages/frontend/src/lib/upstream/stores/breadcrumb.ts
@@ -20,7 +20,7 @@ import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
 import type { TinroBreadcrumb } from 'tinro';
 
-const home = { name: 'Dashboard', path: '/' } as TinroBreadcrumb;
+const home = { name: 'Bootable Containers', path: '/' } as TinroBreadcrumb;
 export const currentPage: Writable<TinroBreadcrumb> = writable(home);
 export const lastPage: Writable<TinroBreadcrumb> = writable(home);
 export const history: Writable<TinroBreadcrumb[]> = writable([home]);


### PR DESCRIPTION
nit: fix naming to match extension

### What does this PR do?

Fixes the naming BootC to Bootable Container like the rest of the
extension.

This includes any breadcrumbs as well.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

Build / view the pages.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
