### PR TITLE
chore: create unique entries in history when building

### DIFF
--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -113,4 +113,8 @@ export class BootcApiImpl implements BootcApi {
   async openFolder(folder: string): Promise<boolean> {
     return await podmanDesktopApi.env.openExternal(podmanDesktopApi.Uri.file(folder));
   }
+
+  async generateUniqueBuildID(name: string): Promise<string> {
+    return this.history.getUnusedHistoryName(name);
+  }
 }

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -34,7 +34,7 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History): P
   let errorMessage: string;
 
   const requiredFields = [
-    { field: 'name', message: 'Bootc image name is required.' },
+    { field: 'id', message: 'Bootc image id is required.' },
     { field: 'tag', message: 'Bootc image tag is required.' },
     { field: 'type', message: 'Bootc image type is required.' },
     { field: 'engineId', message: 'Bootc image engineId is required.' },
@@ -100,12 +100,13 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History): P
   // "Returning" withProgress allows PD to handle the task in the background with building.
   return extensionApi.window
     .withProgress(
-      { location: extensionApi.ProgressLocation.TASK_WIDGET, title: 'Building disk image ' + build.name },
+      { location: extensionApi.ProgressLocation.TASK_WIDGET, title: `Building disk image ${build.image}` },
       async progress => {
-        const buildContainerName = build.name.split('/').pop() + bootcImageBuilderContainerName;
+        const buildContainerName = build.image.split('/').pop() + bootcImageBuilderContainerName;
         let successful: boolean = false;
         let logData: string = 'Build Image Log --------\n';
-        logData += 'Image:  ' + build.name + '\n';
+        logData += 'ID:     ' + build.id + '\n';
+        logData += 'Image:  ' + build.image + '\n';
         logData += 'Type:   ' + build.type + '\n';
         logData += 'Folder: ' + build.folder + '\n';
         logData += '----------\n';
@@ -125,7 +126,7 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History): P
         const containerName = await getUnusedName(buildContainerName);
         const buildImageContainer = createBuilderImageOptions(
           containerName,
-          `${build.name}:${build.tag}`,
+          `${build.image}:${build.tag}`,
           build.type,
           build.arch,
           build.folder,
@@ -200,7 +201,7 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History): P
             const historyExists = history.getHistory().some(info => info.buildContainerId === containerId);
             if (!historyExists) {
               console.error(
-                `Container ${build.buildContainerId} for build ${build.name}:${build.arch} has errored out, but there is no container history. This is likely due to the container being removed intentionally during the build cycle. Ignore this. Error: ${error}`,
+                `Container ${build.buildContainerId} for build ${build.image}:${build.arch} has errored out, but there is no container history. This is likely due to the container being removed intentionally during the build cycle. Ignore this. Error: ${error}`,
               );
               return;
             } else {

--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -36,9 +36,13 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     extensionApi.commands.registerCommand('bootc.image.build', async image => {
       const selections = await bootcBuildOptionSelection(history);
       if (selections) {
+        // Get a unique name for the build
+        const name = await history.getUnusedHistoryName(image.name);
+
         await buildDiskImage(
           {
-            name: image.name,
+            id: name,
+            image: image.name,
             tag: image.tag,
             engineId: image.engineId,
             type: selections.type,

--- a/packages/backend/src/history.spec.ts
+++ b/packages/backend/src/history.spec.ts
@@ -42,7 +42,8 @@ describe('History class tests', () => {
     const history = new History(tmpFilePath);
 
     await history.addOrUpdateBuildInfo({
-      name: 'exampleName',
+      id: 'exampleName',
+      image: 'exampleImageName',
       tag: 'exampleTag',
       engineId: 'exampleEngineId',
       type: 'exampleType',
@@ -69,7 +70,8 @@ describe('History class tests', () => {
     const history = new History(tmpFilePath);
 
     await history.addOrUpdateBuildInfo({
-      name: 'exampleName0',
+      id: 'name1',
+      image: 'exampleName0',
       tag: 'exampleTag0',
       engineId: 'exampleEngineId0',
       type: 'exampleType0',
@@ -79,7 +81,8 @@ describe('History class tests', () => {
     });
 
     await history.addOrUpdateBuildInfo({
-      name: 'exampleName1',
+      id: 'name1',
+      image: 'exampleName1',
       tag: 'exampleTag1',
       engineId: 'exampleEngineId1',
       type: 'exampleType1',
@@ -89,7 +92,8 @@ describe('History class tests', () => {
     });
 
     await history.addOrUpdateBuildInfo({
-      name: 'exampleName2',
+      id: 'name1',
+      image: 'exampleName2',
       tag: 'exampleTag2',
       engineId: 'exampleEngineId2',
       type: 'exampleType2',

--- a/packages/backend/src/history.ts
+++ b/packages/backend/src/history.ts
@@ -45,19 +45,16 @@ export class History {
 
       const infoBuffer = await readFile(filePath, 'utf8');
       this.infos = JSON.parse(infoBuffer);
+
+      // Sometimes the history file may have undefined names due to an older version, ensure all names are set
+      await this.ensureNoUndefinedNames();
     } catch (err) {
       console.error(err);
     }
   }
 
   public async addOrUpdateBuildInfo(buildInfo: BootcBuildInfo): Promise<void> {
-    const index = this.infos.findIndex(
-      info =>
-        info.name === buildInfo.name &&
-        info.type === buildInfo.type &&
-        info.arch === buildInfo.arch &&
-        info.tag === buildInfo.tag,
-    );
+    const index = this.infos.findIndex(info => info.id === buildInfo.id);
     if (index !== -1) {
       this.infos[index] = { ...this.infos[index], ...buildInfo };
     } else {
@@ -70,16 +67,8 @@ export class History {
     await this.saveFile();
   }
 
-  public async removeBuildInfo(buildInfo: Pick<BootcBuildInfo, 'name' | 'tag' | 'type' | 'arch'>): Promise<void> {
-    this.infos = this.infos.filter(
-      info =>
-        !(
-          info.name === buildInfo.name &&
-          info.type === buildInfo.type &&
-          info.arch === buildInfo.arch &&
-          info.tag === buildInfo.tag
-        ),
-    );
+  public async removeBuildInfo(buildInfo: BootcBuildInfo): Promise<void> {
+    this.infos = this.infos.filter(info => !(info.id === buildInfo.id));
     await this.saveFile();
   }
 
@@ -95,5 +84,55 @@ export class History {
 
   public getLastFolder(): string | undefined {
     return this.infos?.[0]?.folder;
+  }
+
+  // Check the history file for any undefined "name" fields, if they are undefined, set them to a unique name
+  // and save the history file. This is because this is from an older version of the extension where the name
+  // field was not required. Rather than deleting the file, we'll just update it with the new field.
+  public async ensureNoUndefinedNames(): Promise<void> {
+    let changed = false;
+    for (let i = 0; i < this.infos.length; i++) {
+      if (!this.infos[i].id) {
+        // Update the 'name' field with the name of the image
+        const segments = this.infos[i].image.split('/');
+        const imageName = segments?.pop() ?? this.infos[i].image; // Fallback to name if split is an empty last segment
+        this.infos[i].id = await this.getUnusedHistoryName(imageName);
+        console.log(`Updated history entry ${this.infos[i].image} with name: ${this.infos[i].id}`);
+        changed = true;
+      }
+    }
+    if (changed) {
+      await this.saveFile();
+    }
+  }
+
+  // same as getUnusedName from build-disk-image.ts but instead checks from the history information.
+  public async getUnusedHistoryName(name: string): Promise<string> {
+    // Extract the last segment after the last '/' as the imageName.
+    const segments = name.split('/');
+    const imageName = segments.pop() ?? name; // Fallback to name if split is an empty last segment
+
+    let builds: string[] = [];
+    try {
+      // Get a list of all existing container names.
+      builds = this.infos.map(c => c.id);
+    } catch (e) {
+      console.warn('Could not get existing container names');
+      console.warn(e);
+    }
+
+    // Check if the imageName is unique, and find a unique name by appending a count if necessary.
+    if (builds.includes(imageName)) {
+      let count = 2; // Start with 2 since imageName without a suffix is considered the first
+      let newName: string;
+      do {
+        newName = `${imageName}-${count}`;
+        count++;
+      } while (builds.includes(newName));
+      return newName;
+    }
+
+    // If imageName is already unique, return it as is.
+    return imageName;
   }
 }

--- a/packages/backend/src/quickpicks.spec.ts
+++ b/packages/backend/src/quickpicks.spec.ts
@@ -37,7 +37,8 @@ describe('bootcBuildOptionSelection', () => {
 
     const history = new History(tempFilePath);
     await history.addOrUpdateBuildInfo({
-      name: 'exampleName',
+      id: 'name1',
+      image: 'exampleImage',
       tag: 'exampleTag',
       engineId: 'exampleEngineId',
       type: 'exampleType',

--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -25,7 +25,8 @@ import { bootcClient } from './api/client';
 
 const mockHistoryInfo: BootcBuildInfo[] = [
   {
-    name: 'image1',
+    id: 'name1',
+    image: 'image1',
     engineId: 'engine1',
     tag: 'latest',
     type: 'iso',
@@ -33,7 +34,8 @@ const mockHistoryInfo: BootcBuildInfo[] = [
     arch: 'x86_64',
   },
   {
-    name: 'image2',
+    id: 'name2',
+    image: 'image2',
     engineId: 'engine2',
     tag: 'latest',
     type: 'iso',

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -43,7 +43,7 @@ async function fillBuildOptions() {
     // Find the image that matches the latest build's name and tag and set selectedImage to that value
     selectedImage = bootcAvailableImages.find(
       image =>
-        image.RepoTags && image.RepoTags.length > 0 && image.RepoTags[0] === `${latestBuild.name}:${latestBuild.tag}`,
+        image.RepoTags && image.RepoTags.length > 0 && image.RepoTags[0] === `${latestBuild.image}:${latestBuild.tag}`,
     );
   }
 }
@@ -74,9 +74,14 @@ async function buildBootcImage() {
     return;
   }
 
+  // Before building a disk image name, we get a unique unused identifier for this image
+  // This is to prevent the user from accidentally overwriting an history
+  const buildID = await bootcClient.generateUniqueBuildID(buildImageName);
+
   // The build options
   const buildOptions: BootcBuildInfo = {
-    name: buildImageName,
+    id: buildID,
+    image: buildImageName,
     tag: buildTag,
     engineId: buildEngineId,
     folder: buildFolder,
@@ -101,7 +106,7 @@ async function buildBootcImage() {
       const historyInfo = await bootcClient.listHistoryInfo();
       const found = historyInfo.find(
         info =>
-          info.name === buildImageName && info.tag === buildTag && info.type === buildType && info.arch === buildArch,
+          info.image === buildImageName && info.tag === buildTag && info.type === buildType && info.arch === buildArch,
       );
 
       if (found) {

--- a/packages/frontend/src/Homepage.spec.ts
+++ b/packages/frontend/src/Homepage.spec.ts
@@ -24,7 +24,8 @@ import { beforeEach } from 'node:test';
 
 const mockHistoryInfo: BootcBuildInfo[] = [
   {
-    name: 'image1',
+    id: 'name1',
+    image: 'image1',
     engineId: 'engine1',
     tag: 'latest',
     type: 'iso',
@@ -32,7 +33,8 @@ const mockHistoryInfo: BootcBuildInfo[] = [
     arch: 'x86_64',
   },
   {
-    name: 'image2',
+    id: 'name2',
+    image: 'image2',
     engineId: 'engine2',
     tag: 'latest',
     type: 'iso',

--- a/packages/frontend/src/Homepage.svelte
+++ b/packages/frontend/src/Homepage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { onDestroy, onMount } from 'svelte';
+import { onMount } from 'svelte';
 import { router } from 'tinro';
 import type { BootcBuildInfo } from '/@shared/src/models/bootc';
 import NavPage from './lib/upstream/NavPage.svelte';
@@ -11,12 +11,12 @@ import BootcColumnActions from './lib/BootcColumnActions.svelte';
 import { bootcClient } from './api/client';
 import SimpleColumn from './lib/upstream/SimpleColumn.svelte';
 import BootcStatus from './lib/BootcStatus.svelte';
-import BootcNameColumn from './lib/BootcImageColumn.svelte';
 import { searchPattern, filtered } from './stores/historyInfo';
 import BootcIcon from './lib/BootcIcon.svelte';
 import FilteredEmptyScreen from './lib/upstream/FilteredEmptyScreen.svelte';
 import BootcEmptyScreen from './lib/BootcEmptyScreen.svelte';
 import BootcFolderColumn from './lib/BootcFolderColumn.svelte';
+import BootcImageColumn from './lib/BootcImageColumn.svelte';
 
 // Search functionality
 export let searchTerm = '';
@@ -66,8 +66,8 @@ let statusColumn = new Column<BootcBuildInfo>('Status', {
 
 let imageColumn = new Column<BootcBuildInfo>('Image', {
   width: '2fr',
-  renderer: BootcNameColumn,
-  comparator: (a, b) => a.name.localeCompare(b.name),
+  renderer: BootcImageColumn,
+  comparator: (a, b) => a.image.localeCompare(b.image),
 });
 
 let typeColumn = new Column<BootcBuildInfo, string>('Type', {

--- a/packages/frontend/src/lib/BootcActions.spec.ts
+++ b/packages/frontend/src/lib/BootcActions.spec.ts
@@ -37,7 +37,8 @@ vi.mock('../api/client', async () => {
 });
 
 const mockHistoryInfo: BootcBuildInfo = {
-  name: 'image1',
+  id: 'name1',
+  image: 'image1',
   engineId: 'engine1',
   tag: 'latest',
   type: 'iso',

--- a/packages/frontend/src/lib/BootcColumnActions.spec.ts
+++ b/packages/frontend/src/lib/BootcColumnActions.spec.ts
@@ -21,7 +21,8 @@ import { screen, render } from '@testing-library/svelte';
 import BootcColumnActions from './BootcColumnActions.svelte';
 
 const mockHistoryInfo: BootcBuildInfo = {
-  name: 'image1',
+  id: 'name1',
+  image: 'image1',
   engineId: 'engine1',
   tag: 'latest',
   type: 'iso',

--- a/packages/frontend/src/lib/BootcFolderColumn.spec.ts
+++ b/packages/frontend/src/lib/BootcFolderColumn.spec.ts
@@ -21,7 +21,8 @@ import { screen, render } from '@testing-library/svelte';
 import BootcFolderColumn from './BootcFolderColumn.svelte';
 
 const mockHistoryInfo: BootcBuildInfo = {
-  name: 'image1',
+  id: 'name1',
+  image: 'image1',
   engineId: 'engine1',
   tag: 'latest',
   type: 'iso',

--- a/packages/frontend/src/lib/BootcImageColumn.spec.ts
+++ b/packages/frontend/src/lib/BootcImageColumn.spec.ts
@@ -21,7 +21,8 @@ import { screen, render } from '@testing-library/svelte';
 import BootcImageColumn from './BootcImageColumn.svelte';
 
 const mockHistoryInfo: BootcBuildInfo = {
-  name: 'image1',
+  id: 'name1',
+  image: 'image1',
   engineId: 'engine1',
   tag: 'latest',
   type: 'iso',

--- a/packages/frontend/src/lib/BootcImageColumn.svelte
+++ b/packages/frontend/src/lib/BootcImageColumn.svelte
@@ -5,5 +5,5 @@ export let object: BootcBuildInfo;
 </script>
 
 <div class="text-sm text-gray-300">
-  {object.name}:{object.tag}
+  {object.image}:{object.tag}
 </div>

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -26,4 +26,5 @@ export abstract class BootcApi {
   abstract listBootcImages(): Promise<ImageInfo[]>;
   abstract listHistoryInfo(): Promise<BootcBuildInfo[]>;
   abstract openFolder(folder: string): Promise<boolean>;
+  abstract generateUniqueBuildID(name: string): Promise<string>;
 }

--- a/packages/shared/src/models/bootc.ts
+++ b/packages/shared/src/models/bootc.ts
@@ -17,7 +17,8 @@
  ***********************************************************************/
 
 export interface BootcBuildInfo {
-  name: string;
+  id: string;
+  image: string;
   tag: string;
   engineId: string;
   type: string;


### PR DESCRIPTION
chore: create unique entries in history when building

### What does this PR do?

* Instead of overriding the previous history, create a unique entry
  using name
* Adds 'name' to the interface

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/containers/podman-desktop-extension-bootc/assets/6422176/dc2ba8f1-a04b-4219-8edc-0777b45eabf1



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/201

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Delete `rm
   ~/.local/share/containers/podman-desktop/extensions-storage/redhat.bootc/history.json`
2. Create multiple builds, they should appear now as multiple builds.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
