### PR TITLE
chore: update PD dependency

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -30,6 +30,6 @@ FROM scratch
 LABEL org.opencontainers.image.title="Bootable Container Extension" \
         org.opencontainers.image.description="Podman Desktop extension for bootable OS containers (bootc) and generating disk images" \
         org.opencontainers.image.vendor="Red Hat" \
-        io.podman-desktop.api.version=">= 1.7.0"
+        io.podman-desktop.api.version=">= 1.8.0"
 
 COPY --from=builder /extension /extension

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "typescript": "5.3.3",
     "vite": "^5.1.3",
     "vitest": "^1.4.0"
-    
   },
   "workspaces": {
     "packages": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -74,7 +74,8 @@
     "watch": "vite --mode development build -w"
   },
   "devDependencies": {
-    "@podman-desktop/api": "0.0.202402162135-b6e663e",
+    "@podman-desktop/api": "1.8.0",
+    "@types/node": "^20",
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "@typescript-eslint/parser": "^6.16.0",
     "@vitest/coverage-v8": "^1.1.0",
@@ -86,7 +87,6 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-redundant-undefined": "^1.0.0",
     "eslint-plugin-sonarjs": "^0.23.0",
-    "@types/node": "^20",
     "prettier": "^3.1.1",
     "typescript": "5.3.3",
     "vite": "^5.0.10",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -25,7 +25,7 @@
     "@fortawesome/free-brands-svg-icons": "^6.5.1",
     "@fortawesome/free-regular-svg-icons": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
-    "@podman-desktop/ui-svelte": "^0.0.202403121758-79e035f",
+    "@podman-desktop/ui-svelte": "^0.0.202403131824-ebad3b0",
     "@sveltejs/vite-plugin-svelte": "3.0.1",
     "@tailwindcss/typography": "^0.5.10",
     "@testing-library/dom": "^9.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -408,10 +408,10 @@
   dependencies:
     playwright "1.42.1"
 
-"@podman-desktop/api@0.0.202402162135-b6e663e":
-  version "0.0.202402162135-b6e663e"
-  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-0.0.202402162135-b6e663e.tgz#7d9549e093b46a4958d046b74baa131e25a04ce9"
-  integrity sha512-sAVfni2uzUcdNX/PfZh5JI3Z9401KJz9ZVANE8kpvxpNpLURjcuwPViyhBu1FpP6kusd+rRulFVtV/ZS5Ka2yQ==
+"@podman-desktop/api@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-1.8.0.tgz#03205b1b1685c4208a0739d99ac23bb4c749da60"
+  integrity sha512-z+eTWLQOdhSNxz4KtgMmCaCjghCYPsXoxrMN2NZdDxwoljWmVNB7Q3X/+s1cl7r3hrjwnS6EfZzoYJWQgx9WCQ==
 
 "@podman-desktop/tests-playwright@^0.0.202403201348-23ebd88":
   version "0.0.202403201348-66734ce"


### PR DESCRIPTION
### What does this PR do?

Update the version of Podman Desktop we depend on to 1.8, and align on a single ui-svelte package (currently there are two different versions in frontend/package.json).

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Just regular build tests.