### PR TITLE
chore: expose pull image API

### DIFF
--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -99,7 +99,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
 
   // Register the 'api' for the webview to communicate to the backend
   const rpcExtension = new RpcExtension(panel.webview);
-  const bootcApi = new BootcApiImpl(extensionContext);
+  const bootcApi = new BootcApiImpl(extensionContext, panel.webview);
   rpcExtension.registerInstance<BootcApiImpl>(BootcApiImpl, bootcApi);
 
   // Create the historyNotifier and push to subscriptions

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -21,6 +21,7 @@ import type { ImageInfo } from '@podman-desktop/api';
 
 export abstract class BootcApi {
   abstract buildImage(build: BootcBuildInfo): Promise<void>;
+  abstract pullImage(image: string): Promise<void>;
   abstract deleteBuilds(builds: BootcBuildInfo[]): Promise<void>;
   abstract selectOutputFolder(): Promise<string>;
   abstract listBootcImages(): Promise<ImageInfo[]>;

--- a/packages/shared/src/messages/Messages.ts
+++ b/packages/shared/src/messages/Messages.ts
@@ -18,4 +18,5 @@
 
 export enum Messages {
   MSG_HISTORY_UPDATE = 'history-update',
+  MSG_IMAGE_PULL_UPDATE = 'image-pull-update', // Responsible for any pull updates
 }


### PR DESCRIPTION
chore: expose pull image API

### What does this PR do?

* Adds pull image API for the frontend to use
* Adds notify to api-impl.ts for the frontend to be able to push updates

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

References https://github.com/containers/podman-desktop-extension-bootc/issues/150

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/237

### How to test this PR?

<!-- Please explain steps to reproduce -->

Use `bootcClient.pullImage("quay.io/your/test/image");` within the code

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
