### PR TITLE
chore: temporarily ignore arch when building iso

### DIFF
--- a/packages/backend/src/build-disk-image.spec.ts
+++ b/packages/backend/src/build-disk-image.spec.ts
@@ -40,7 +40,7 @@ beforeEach(() => {
 
 test('check image builder options', async () => {
   const image = 'test-image';
-  const type = 'iso';
+  const type = 'raw';
   const arch = 'amd';
   const name = 'my-image';
   const outputFolder = '/output-folder';
@@ -59,7 +59,7 @@ test('check image builder options', async () => {
 
 test('check image builder with multiple types', async () => {
   const image = 'test-image';
-  const type: BuildType[] = ['iso', 'vmdk'];
+  const type: BuildType[] = ['raw', 'vmdk'];
   const arch = 'amd';
   const name = 'my-image';
   const outputFolder = '/output-folder';
@@ -89,10 +89,23 @@ test('check image builder with multiple types', async () => {
 
 test('check image builder does not include target arch', async () => {
   const image = 'test-image';
-  const type = 'iso';
+  const type = 'vmdk';
   const name = 'my-image';
   const outputFolder = '/output-folder';
   const options = createBuilderImageOptions(name, image, [type], undefined, outputFolder);
+
+  expect(options).toBeDefined();
+  expect(options.Cmd).not.toContain('--target-arch');
+});
+
+// temporary test, see createBuilderImageOptions
+test('temporarily check image builder does not include target arch for iso', async () => {
+  const image = 'test-image';
+  const type = 'iso';
+  const arch = 'amd';
+  const name = 'my-image';
+  const outputFolder = '/output-folder';
+  const options = createBuilderImageOptions(name, image, [type], arch, outputFolder);
 
   expect(options).toBeDefined();
   expect(options.Cmd).not.toContain('--target-arch');

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -326,7 +326,13 @@ export function createBuilderImageOptions(
   const cmd = [image, '--output', '/output/', '--local'];
 
   type.forEach(t => cmd.push('--type', t));
-  if (arch) {
+
+  // bootc image builder does not currently support specifying a target arch
+  // (even the current/default one) when building an iso. Enough people are
+  // hitting this that we are putting in a temporary workaround until the
+  // following issue is resolved:
+  // https://github.com/osbuild/bootc-image-builder/issues/316
+  if (arch && !type.find(buildType => buildType === 'iso')) {
     cmd.push('--target-arch', arch);
   }
 


### PR DESCRIPTION
### What does this PR do?

Image builder has had an issue for a while now where if you specify the target arch when building an iso it will fail, even if you're specifying the current/default arch. We've had enough users hit this (so this extension is the 'blocking' issue) even though the generated images are also broken/unusable.

We've discussed possible UI changes (like having a 'no target arch' option, or allowing no arch to be selected) but we don't really like these and do not want to make UI changes that could be very temporary - so this is the simplest workaround for now that will unblock users.

Once the following bug is resolved we will update image builder, remove this workaround, and if necessary change the UI.

https://github.com/osbuild/bootc-image-builder/issues/316

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Temporary fix for #149.

### How to test this PR?

Build an iso and confirm image builder doesn't fail.