### PR TITLE
build-disk: Clarify output message

### DIFF
--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -252,7 +252,7 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History): P
       if (build.status === 'success') {
         // Notify the user that the image has been built successfully
         await extensionApi.window.showInformationMessage(
-          `Success! Your Bootable OS Container has been succesfully created to ${build.folder}`,
+          `Success! A disk image derived from your bootable container has been succesfully created in ${build.folder}`,
           'OK',
         );
       } else {


### PR DESCRIPTION
Every single time someone says "image" in contexts like this I will stop them and make them clarify, are they talking about a "disk image" or a "container image" - they're different things!

This message seems to imply a *container* was created.  No, the container was already made.  What we're doing here is generating a disk image.

(Also, "in" makes more sense than "to" when talking about folders)
