### PR TITLE
feat: error if running on older podman version

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -91,5 +91,8 @@
     "typescript": "5.3.3",
     "vite": "^5.0.12",
     "vitest": "^1.1.0"
+  },
+  "dependencies": {
+    "semver": "^7.6.0"
   }
 }

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -58,6 +58,13 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History): P
     throw new Error('The podman machine is not set as rootful.');
   }
 
+  const isPodmanV5 = await machineUtils.isPodmanV5Machine();
+  if (!isPodmanV5) {
+    const errorMessage = 'Podman v5.0 or higher is required to build disk images.';
+    await extensionApi.window.showErrorMessage(errorMessage);
+    throw new Error('The podman machine version is below v5.0.');
+  }
+
   // Use build.type to check for existing files
   let promptForOverwrite: boolean = false;
 

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -62,7 +62,7 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History): P
   if (!isPodmanV5) {
     const errorMessage = 'Podman v5.0 or higher is required to build disk images.';
     await extensionApi.window.showErrorMessage(errorMessage);
-    throw new Error('The podman machine version is below v5.0.');
+    throw new Error('Podman Machine is below v5.0.');
   }
 
   // Use build.type to check for existing files

--- a/packages/backend/src/machine-utils.spec.ts
+++ b/packages/backend/src/machine-utils.spec.ts
@@ -158,3 +158,59 @@ test('Pass true if Rootful is in HostUser', async () => {
   spyReadFile.mockResolvedValue(JSON.stringify({ HostUser: { Rootful: true } }));
   await expect(machineUtils.isPodmanMachineRootful()).resolves.toBe(true);
 });
+
+test('Check isPodmanV5Machine on 4.9', async () => {
+  const fakeMachineInfoJSON = {
+    Version: {
+      Version: '4.9.4',
+    },
+  };
+
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>(resolve => {
+        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
+      }),
+  );
+
+  // Mock existsSync to return true (the "fake" file is there)
+  vi.mock('node:fs');
+  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
+    return true;
+  });
+
+  // Mock the readFile function to return the "fake" file with rootful being true
+  const spyReadFile = vi.spyOn(fs.promises, 'readFile');
+
+  // Mock reading the file to have Rootful as true
+  spyReadFile.mockResolvedValue(JSON.stringify({ Rootful: true }));
+  await expect(machineUtils.isPodmanV5Machine()).resolves.toBe(false);
+});
+
+test('Check isPodmanV5Machine on 5.0', async () => {
+  const fakeMachineInfoJSON = {
+    Version: {
+      Version: '5.0.0',
+    },
+  };
+
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>(resolve => {
+        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
+      }),
+  );
+
+  // Mock existsSync to return true (the "fake" file is there)
+  vi.mock('node:fs');
+  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
+    return true;
+  });
+
+  // Mock the readFile function to return the "fake" file with rootful being true
+  const spyReadFile = vi.spyOn(fs.promises, 'readFile');
+
+  // Mock reading the file to have Rootful as true
+  spyReadFile.mockResolvedValue(JSON.stringify({ Rootful: true }));
+  await expect(machineUtils.isPodmanV5Machine()).resolves.toBe(true);
+});

--- a/packages/backend/src/machine-utils.ts
+++ b/packages/backend/src/machine-utils.ts
@@ -20,6 +20,7 @@ import * as extensionApi from '@podman-desktop/api';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
+import { satisfies } from 'semver';
 
 // Async function to get machine information in JSON format
 async function getMachineInfo() {
@@ -69,6 +70,19 @@ export async function isPodmanMachineRootful() {
     }
   } catch (error) {
     console.error('Error when checking rootful machine status:', error);
+    return false; // Ensure function returns a boolean even in case of error
+  }
+}
+
+// Check if the current podman machine is v5 or above
+export async function isPodmanV5Machine() {
+  try {
+    const machineInfo = await getMachineInfo();
+
+    const ver = machineInfo.Version.Version;
+    return satisfies(ver, '>=5.0.0');
+  } catch (error) {
+    console.error('Error when checking Podman machine version:', error);
     return false; // Ensure function returns a boolean even in case of error
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3603,7 +3603,7 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.23, postcss@^8.4.35, postcss@^8.4.36:
+postcss@^8.4.23, postcss@^8.4.35, postcss@^8.4.36, postcss@^8.4.38:
   version "8.4.38"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.38.tgz#b387d533baf2054288e337066d81c6bee9db9e0e"
   integrity sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==
@@ -3904,7 +3904,7 @@ semver@^6.2.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.2, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
+semver@^7.3.2, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
   integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
@@ -4560,13 +4560,24 @@ vite-node@1.4.0:
     picocolors "^1.0.0"
     vite "^5.0.0"
 
-vite@^5.0.0, vite@^5.0.10, vite@^5.1.1, vite@^5.1.3:
+vite@^5.0.0, vite@^5.1.1, vite@^5.1.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/vite/-/vite-5.2.3.tgz#198efc2fd4d80eac813b146a68a4b0dbde884fc2"
   integrity sha512-+i1oagbvkVIhEy9TnEV+fgXsng13nZM90JQbrcPrf6DvW2mXARlz+DK7DLiDP+qeKoD1FCVx/1SpFL1CLq9Mhw==
   dependencies:
     esbuild "^0.20.1"
     postcss "^8.4.36"
+    rollup "^4.13.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vite@^5.0.12:
+  version "5.2.7"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-5.2.7.tgz#e1b8a985eb54fcb9467d7f7f009d87485016df6e"
+  integrity sha512-k14PWOKLI6pMaSzAuGtT+Cf0YmIx12z9YGon39onaJNy8DLBfBJrzg9FQEmkAM5lpHBZs9wksWAsyF/HkpEwJA==
+  dependencies:
+    esbuild "^0.20.1"
+    postcss "^8.4.38"
     rollup "^4.13.0"
   optionalDependencies:
     fsevents "~2.3.3"


### PR DESCRIPTION
### What does this PR do?

Provide a function to test if the machine we're running on is Podman v5 or higher, and use it to trigger an error if we try running an image build on an older machine.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #168.

### How to test this PR?

Automated tests; try running a build with a <5.0 machine.