### PR TITLE
chore: add inspectImage API

### DIFF
--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -113,6 +113,19 @@ export class BootcApiImpl implements BootcApi {
     return images;
   }
 
+  async inspectImage(image: ImageInfo): Promise<podmanDesktopApi.ImageInspectInfo> {
+    let imageInspect: podmanDesktopApi.ImageInspectInfo;
+    try {
+      imageInspect = await podmanDesktopApi.containerEngine.getImageInspect(image.engineId, image.Id);
+    } catch (err) {
+      throw new Error(`Error inspecting image: ${err}`);
+    }
+    if (imageInspect === undefined) {
+      throw new Error('Unable to retrieve image inspect information');
+    }
+    return imageInspect;
+  }
+
   async listHistoryInfo(): Promise<BootcBuildInfo[]> {
     try {
       // Load the file so it retrieves the latest information.

--- a/packages/backend/src/container-utils.spec.ts
+++ b/packages/backend/src/container-utils.spec.ts
@@ -26,6 +26,7 @@ import {
   removeContainerIfExists,
   removeContainerAndVolumes,
   deleteOldImages,
+  inspectImage,
 } from './container-utils';
 
 const mocks = vi.hoisted(() => ({
@@ -213,4 +214,15 @@ test('deleteOldImages should remove images with other tags', async () => {
   await deleteOldImages('podman', 'test.io/name:2');
   expect(deleteImageMock).toHaveBeenCalledTimes(2);
   expect(deletedIds).toEqual(['i1', 'i3']);
+});
+
+test('test running inspectImage', async () => {
+  const image = { engineId: 'podman', Id: 'i1' };
+  const inspectImageMock = vi.fn().mockResolvedValue({ Id: 'i1' });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (extensionApi.containerEngine as any).getImageInspect = inspectImageMock;
+
+  // Test that it'll call getImageInspect (returns i1)
+  const result = await inspectImage(image.engineId, image.Id);
+  expect(result.Id).toBe('i1');
 });

--- a/packages/backend/src/container-utils.ts
+++ b/packages/backend/src/container-utils.ts
@@ -45,6 +45,17 @@ export async function getContainerEngine(): Promise<extensionApi.ContainerProvid
   return runningPodmanConnections[0].connection;
 }
 
+// Inspect the image / get more information
+export async function inspectImage(engineId: string, image: string): Promise<extensionApi.ImageInspectInfo> {
+  console.log('Inspecting image: ', image);
+  try {
+    return await extensionApi.containerEngine.getImageInspect(engineId, image);
+  } catch (e) {
+    console.error(e);
+    throw new Error('There was an error inspecting the image: ' + e);
+  }
+}
+
 // Pull the image
 export async function pullImage(image: string) {
   const telemetryData: Record<string, unknown> = {};

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -17,13 +17,14 @@
  l***********************************************************************/
 
 import type { BootcBuildInfo, BuildType } from './models/bootc';
-import type { ImageInfo } from '@podman-desktop/api';
+import type { ImageInfo, ImageInspectInfo } from '@podman-desktop/api';
 
 export abstract class BootcApi {
   abstract checkPrereqs(): Promise<string | undefined>;
   abstract buildExists(folder: string, types: BuildType[]): Promise<boolean>;
   abstract buildImage(build: BootcBuildInfo, overwrite?: boolean): Promise<void>;
   abstract pullImage(image: string): Promise<void>;
+  abstract inspectImage(image: ImageInfo): Promise<ImageInspectInfo>;
   abstract deleteBuilds(builds: BootcBuildInfo[]): Promise<void>;
   abstract selectOutputFolder(): Promise<string>;
   abstract listBootcImages(): Promise<ImageInfo[]>;


### PR DESCRIPTION
chore: add inspectImage API

### What does this PR do?

Adds the inspectImage API for the frontend so that we can inspect the
image for the architecture / OS / more information before building.

Part of https://github.com/containers/podman-desktop-extension-bootc/issues/245

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/containers/podman-desktop-extension-bootc/issues/245

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/339

### How to test this PR?

<!-- Please explain steps to reproduce -->

Covered by tests

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
