### PR TITLE
chore: use bootc icon for menu

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -17,7 +17,8 @@
         {
           "command": "bootc.image.build",
           "title": "Build Disk Image",
-          "when": "ostree.bootable in imageLabelKeys || containers.bootc in imageLabelKeys"
+          "when": "ostree.bootable in imageLabelKeys || containers.bootc in imageLabelKeys",
+          "icon": "${bootable-icon}"
         }
       ]
     },


### PR DESCRIPTION
### What does this PR do?

Not sure how we missed following up, but support for customizing menu action icons was added to PD 1.8. This just sets it to our icon.

### Screenshot / video of UI

<img width="334" alt="Screenshot 2024-04-02 at 4 01 16 PM" src="https://github.com/containers/podman-desktop-extension-bootc/assets/19958075/5acdd720-aadd-4935-8a3e-9fdf9697bcc1">

### What issues does this PR fix or reference?

Fixes #44.

### How to test this PR?

Just go to images view and ensure the menu action has an icon.