### PR TITLE
chore: update bootc-image-builder

### DIFF
--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -18,4 +18,4 @@
 
 // Image related
 export const bootcImageBuilderContainerName = '-bootc-image-builder';
-export const bootcImageBuilderName = 'quay.io/centos-bootc/bootc-image-builder:latest-1710916056';
+export const bootcImageBuilderName = 'quay.io/centos-bootc/bootc-image-builder:latest-1712159106';


### PR DESCRIPTION
### What does this PR do?

We last updated the image builder 2 weeks ago. This moves to the latest, which appears to have significant reduction in peak memory use, possibly negating the need for #221.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Regular automation, test building different image types.