### PR TITLE
fix: be able to test on 5.1.0-dev / dev 5.0.0 podman machine

### DIFF
--- a/packages/backend/src/machine-utils.spec.ts
+++ b/packages/backend/src/machine-utils.spec.ts
@@ -214,3 +214,87 @@ test('Check isPodmanV5Machine on 5.0', async () => {
   spyReadFile.mockResolvedValue(JSON.stringify({ Rootful: true }));
   await expect(machineUtils.isPodmanV5Machine()).resolves.toBe(true);
 });
+
+test('Check isPodmanV5Machine on 5.0.0-dev resolves to be true', async () => {
+  const fakeMachineInfoJSON = {
+    Version: {
+      Version: '5.0.0-dev',
+    },
+  };
+
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>(resolve => {
+        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
+      }),
+  );
+
+  // Mock existsSync to return true (the "fake" file is there)
+  vi.mock('node:fs');
+  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
+    return true;
+  });
+
+  // Mock the readFile function to return the "fake" file with rootful being true
+  const spyReadFile = vi.spyOn(fs.promises, 'readFile');
+
+  // Mock reading the file to have Rootful as true
+  spyReadFile.mockResolvedValue(JSON.stringify({ Rootful: true }));
+  await expect(machineUtils.isPodmanV5Machine()).resolves.toBe(true);
+});
+
+test('Fail if machine version is 4.0.0 for isPodmanV5Machine', async () => {
+  const fakeMachineInfoJSON = {
+    Version: {
+      Version: '4.0.0',
+    },
+  };
+
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>(resolve => {
+        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
+      }),
+  );
+
+  // Mock existsSync to return true (the "fake" file is there)
+  vi.mock('node:fs');
+  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
+    return true;
+  });
+
+  // Mock the readFile function to return the "fake" file with rootful being true
+  const spyReadFile = vi.spyOn(fs.promises, 'readFile');
+
+  // Mock reading the file to have Rootful as true
+  spyReadFile.mockResolvedValue(JSON.stringify({ Rootful: true }));
+  await expect(machineUtils.isPodmanV5Machine()).resolves.toBe(false);
+});
+
+test('Fail if machine version is 4.0.0-dev for isPodmanV5Machine', async () => {
+  const fakeMachineInfoJSON = {
+    Version: {
+      Version: '4.0.0-dev',
+    },
+  };
+
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    () =>
+      new Promise<extensionApi.RunResult>(resolve => {
+        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
+      }),
+  );
+
+  // Mock existsSync to return true (the "fake" file is there)
+  vi.mock('node:fs');
+  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
+    return true;
+  });
+
+  // Mock the readFile function to return the "fake" file with rootful being true
+  const spyReadFile = vi.spyOn(fs.promises, 'readFile');
+
+  // Mock reading the file to have Rootful as true
+  spyReadFile.mockResolvedValue(JSON.stringify({ Rootful: true }));
+  await expect(machineUtils.isPodmanV5Machine()).resolves.toBe(false);
+});


### PR DESCRIPTION
fix: be able to test on 5.1.0-dev / dev 5.0.0 podman machine

### What does this PR do?

* Ability to build on 5.1.0-dev builds.
* Added more tests and validation

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/containers/podman-desktop-extension-bootc/assets/6422176/b4de15d7-16b3-41d6-85ca-a7575dbf4450



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/291

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Run 5.1.0-dev podman machine
2. Be able to build correctly

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
