### PR TITLE
docs: update readme with proper image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ can apply transactional updates "in place" from newly pushed container images (w
 
 For more, see [bootc](https://containers.github.io/bootc/).
 
-The **ONLY** currently supported base image is [`quay.io/centos-bootc/fedora-bootc`](https://centos.github.io/centos-bootc). More are to be supported in the future!
+The **ONLY** currently supported base image is [`quay.io/centos-bootc/centos-bootc`](https://centos.github.io/centos-bootc). More are to be supported in the future!
 
 ## Read Before Using
 


### PR DESCRIPTION
docs: update readme with proper image

### What does this PR do?

It should be linking to quay.io/centos-bootc/centos-bootc as
fedora-bootc is the old one.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

N/A

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
