### PR TITLE
chore: expose validation API

### DIFF
--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -19,12 +19,13 @@
 import * as podmanDesktopApi from '@podman-desktop/api';
 import type { ImageInfo } from '@podman-desktop/api';
 import type { BootcApi } from '/@shared/src/BootcAPI';
-import type { BootcBuildInfo } from '/@shared/src/models/bootc';
+import type { BootcBuildInfo, BuildType } from '/@shared/src/models/bootc';
 import { buildDiskImage } from './build-disk-image';
 import { History } from './history';
 import * as containerUtils from './container-utils';
 import { Messages } from '/@shared/src/messages/Messages';
 import { telemetryLogger } from './extension';
+import { checkPrereqs } from './machine-utils';
 
 export class BootcApiImpl implements BootcApi {
   private history: History;
@@ -38,8 +39,16 @@ export class BootcApiImpl implements BootcApi {
     this.webview = webview;
   }
 
-  async buildImage(build: BootcBuildInfo): Promise<void> {
-    return buildDiskImage(build, this.history);
+  async checkPrereqs(): Promise<string | undefined> {
+    return checkPrereqs();
+  }
+
+  async buildExists(folder: string, types: BuildType[]): Promise<boolean> {
+    return this.buildExists(folder, types);
+  }
+
+  async buildImage(build: BootcBuildInfo, overwrite?: boolean): Promise<void> {
+    return buildDiskImage(build, this.history, overwrite);
   }
 
   async deleteBuilds(builds: BootcBuildInfo[]): Promise<void> {

--- a/packages/backend/src/build-disk-image.spec.ts
+++ b/packages/backend/src/build-disk-image.spec.ts
@@ -23,6 +23,7 @@ import type { ContainerInfo } from '@podman-desktop/api';
 import { containerEngine } from '@podman-desktop/api';
 import type { BuildType } from '/@shared/src/models/bootc';
 import * as fs from 'node:fs';
+import { resolve } from 'node:path';
 
 vi.mock('@podman-desktop/api', async () => {
   return {
@@ -135,7 +136,7 @@ test('check build exists', async () => {
   const folder = '/output';
 
   // mock two existing builds on disk: qcow2 and vmdk
-  const existsList: string[] = ['/output/qcow2/disk.qcow2', '/output/image/disk.vmdk'];
+  const existsList: string[] = [resolve(folder, 'qcow2/disk.qcow2'), resolve(folder, 'image/disk.vmdk')];
   vi.mock('node:fs');
   vi.spyOn(fs, 'existsSync').mockImplementation(f => {
     return existsList.includes(f.toString());

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -28,6 +28,7 @@ import * as machineUtils from './machine-utils';
 import { telemetryLogger } from './extension';
 
 export async function buildExists(folder: string, types: BuildType[]) {
+  let exists = false;
   types.forEach(type => {
     let imageName = ''; // Initialize imageName as an empty string
     if (type === 'qcow2') {
@@ -44,10 +45,10 @@ export async function buildExists(folder: string, types: BuildType[]) {
 
     const imagePath = resolve(folder, imageName);
     if (fs.existsSync(imagePath)) {
-      return true;
+      exists = true;
     }
   });
-  return false;
+  return exists;
 }
 
 export async function buildDiskImage(build: BootcBuildInfo, history: History, overwrite?: boolean): Promise<void> {

--- a/packages/backend/src/machine-utils.spec.ts
+++ b/packages/backend/src/machine-utils.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 import * as extensionApi from '@podman-desktop/api';
 import type { Configuration } from '@podman-desktop/api';
 import * as machineUtils from './machine-utils';
@@ -46,6 +46,10 @@ vi.mock('@podman-desktop/api', async () => {
   };
 });
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 test('Check isPodmanMachineRootful functionality', async () => {
   const fakeMachineInfoJSON = {
     Host: {
@@ -62,24 +66,16 @@ test('Check isPodmanMachineRootful functionality', async () => {
     },
   };
 
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
-    () =>
-      new Promise<extensionApi.RunResult>(resolve => {
-        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
-      }),
+  vi.spyOn(extensionApi.process, 'exec').mockReturnValueOnce(
+    Promise.resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult),
   );
 
   // Mock existsSync to return true (the "fake" file is there)
   vi.mock('node:fs');
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   // Mock the readFile function to return the "fake" file with rootful being true
-  const spyReadFile = vi.spyOn(fs.promises, 'readFile');
-
-  // Mock reading the file to have Rootful as true
-  spyReadFile.mockResolvedValue(JSON.stringify({ Rootful: true }));
+  vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce(JSON.stringify({ Rootful: true }));
   await expect(machineUtils.isPodmanMachineRootful()).resolves.toBe(true);
 });
 
@@ -99,24 +95,16 @@ test('Fail isPodmanMachineRootful functionality be false if Rootful does not exi
     },
   };
 
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
-    () =>
-      new Promise<extensionApi.RunResult>(resolve => {
-        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
-      }),
+  vi.spyOn(extensionApi.process, 'exec').mockReturnValueOnce(
+    Promise.resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult),
   );
 
   // Mock existsSync to return true (the "fake" file is there)
   vi.mock('node:fs');
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   // Mock the readFile function to return the "fake" file with Rootful not existing
-  const spyReadFile = vi.spyOn(fs.promises, 'readFile');
-
-  // Mock reading the file to have Rootful as true
-  spyReadFile.mockResolvedValue(JSON.stringify({}));
+  vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce(JSON.stringify({}));
   await expect(machineUtils.isPodmanMachineRootful()).resolves.toBe(false);
 });
 
@@ -136,24 +124,16 @@ test('Pass true if Rootful is in HostUser', async () => {
     },
   };
 
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
-    () =>
-      new Promise<extensionApi.RunResult>(resolve => {
-        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
-      }),
+  vi.spyOn(extensionApi.process, 'exec').mockReturnValueOnce(
+    Promise.resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult),
   );
 
   // Mock existsSync to return true (the "fake" file is there)
   vi.mock('node:fs');
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   // Mock the readFile function to return the "fake" file with Rootful not existing
-  const spyReadFile = vi.spyOn(fs.promises, 'readFile');
-
-  // Mock reading the file to have Rootful as true
-  spyReadFile.mockResolvedValue(JSON.stringify({ HostUser: { Rootful: true } }));
+  vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce(JSON.stringify({ HostUser: { Rootful: true } }));
   await expect(machineUtils.isPodmanMachineRootful()).resolves.toBe(true);
 });
 
@@ -164,24 +144,16 @@ test('Check isPodmanV5Machine on 4.9', async () => {
     },
   };
 
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
-    () =>
-      new Promise<extensionApi.RunResult>(resolve => {
-        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
-      }),
+  vi.spyOn(extensionApi.process, 'exec').mockReturnValueOnce(
+    Promise.resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult),
   );
 
   // Mock existsSync to return true (the "fake" file is there)
   vi.mock('node:fs');
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   // Mock the readFile function to return the "fake" file with rootful being true
-  const spyReadFile = vi.spyOn(fs.promises, 'readFile');
-
-  // Mock reading the file to have Rootful as true
-  spyReadFile.mockResolvedValue(JSON.stringify({ Rootful: true }));
+  vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce(JSON.stringify({ Rootful: true }));
   await expect(machineUtils.isPodmanV5Machine()).resolves.toBe(false);
 });
 
@@ -192,24 +164,16 @@ test('Check isPodmanV5Machine on 5.0', async () => {
     },
   };
 
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
-    () =>
-      new Promise<extensionApi.RunResult>(resolve => {
-        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
-      }),
+  vi.spyOn(extensionApi.process, 'exec').mockReturnValueOnce(
+    Promise.resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult),
   );
 
   // Mock existsSync to return true (the "fake" file is there)
   vi.mock('node:fs');
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   // Mock the readFile function to return the "fake" file with rootful being true
-  const spyReadFile = vi.spyOn(fs.promises, 'readFile');
-
-  // Mock reading the file to have Rootful as true
-  spyReadFile.mockResolvedValue(JSON.stringify({ Rootful: true }));
+  vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce(JSON.stringify({ Rootful: true }));
   await expect(machineUtils.isPodmanV5Machine()).resolves.toBe(true);
 });
 
@@ -220,24 +184,16 @@ test('Check isPodmanV5Machine on 5.0.0-dev resolves to be true', async () => {
     },
   };
 
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
-    () =>
-      new Promise<extensionApi.RunResult>(resolve => {
-        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
-      }),
+  vi.spyOn(extensionApi.process, 'exec').mockReturnValueOnce(
+    Promise.resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult),
   );
 
   // Mock existsSync to return true (the "fake" file is there)
   vi.mock('node:fs');
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   // Mock the readFile function to return the "fake" file with rootful being true
-  const spyReadFile = vi.spyOn(fs.promises, 'readFile');
-
-  // Mock reading the file to have Rootful as true
-  spyReadFile.mockResolvedValue(JSON.stringify({ Rootful: true }));
+  vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce(JSON.stringify({ Rootful: true }));
   await expect(machineUtils.isPodmanV5Machine()).resolves.toBe(true);
 });
 
@@ -248,24 +204,16 @@ test('Fail if machine version is 4.0.0 for isPodmanV5Machine', async () => {
     },
   };
 
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
-    () =>
-      new Promise<extensionApi.RunResult>(resolve => {
-        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
-      }),
+  vi.spyOn(extensionApi.process, 'exec').mockReturnValueOnce(
+    Promise.resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult),
   );
 
   // Mock existsSync to return true (the "fake" file is there)
   vi.mock('node:fs');
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   // Mock the readFile function to return the "fake" file with rootful being true
-  const spyReadFile = vi.spyOn(fs.promises, 'readFile');
-
-  // Mock reading the file to have Rootful as true
-  spyReadFile.mockResolvedValue(JSON.stringify({ Rootful: true }));
+  vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce(JSON.stringify({ Rootful: true }));
   await expect(machineUtils.isPodmanV5Machine()).resolves.toBe(false);
 });
 
@@ -276,23 +224,79 @@ test('Fail if machine version is 4.0.0-dev for isPodmanV5Machine', async () => {
     },
   };
 
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
-    () =>
-      new Promise<extensionApi.RunResult>(resolve => {
-        resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult);
-      }),
+  vi.spyOn(extensionApi.process, 'exec').mockReturnValueOnce(
+    Promise.resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult),
   );
 
   // Mock existsSync to return true (the "fake" file is there)
   vi.mock('node:fs');
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   // Mock the readFile function to return the "fake" file with rootful being true
-  const spyReadFile = vi.spyOn(fs.promises, 'readFile');
-
-  // Mock reading the file to have Rootful as true
-  spyReadFile.mockResolvedValue(JSON.stringify({ Rootful: true }));
+  vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce(JSON.stringify({ Rootful: true }));
   await expect(machineUtils.isPodmanV5Machine()).resolves.toBe(false);
+});
+
+test('Fail prereq if not Podman v5', async () => {
+  const fakeMachineInfoJSON = {
+    Version: {
+      Version: '4.9.0',
+    },
+  };
+  vi.spyOn(extensionApi.process, 'exec').mockReturnValueOnce(
+    Promise.resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult),
+  );
+
+  expect(await machineUtils.checkPrereqs()).toEqual('Podman v5.0 or higher is required to build disk images.');
+});
+
+test('Fail prereq if not rootful', async () => {
+  const fakeMachineInfoJSON = {
+    Host: {
+      CurrentMachine: '',
+      MachineConfigDir: '',
+    },
+    Version: {
+      Version: '5.0.0',
+    },
+  };
+  vi.spyOn(extensionApi.process, 'exec').mockReturnValue(
+    Promise.resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult),
+  );
+
+  vi.mock('node:fs');
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+  vi.spyOn(fs.promises, 'readFile').mockReturnValueOnce(
+    Promise.resolve(JSON.stringify({ HostUser: { Rootful: false } })),
+  );
+
+  expect(await machineUtils.checkPrereqs()).toEqual(
+    'The podman machine is not set as rootful. Please recreate the podman machine with rootful privileges set and try again.',
+  );
+});
+
+test('Pass prereq if rootful v5 machine', async () => {
+  const fakeMachineInfoJSON = {
+    Host: {
+      CurrentMachine: '',
+      MachineConfigDir: '',
+    },
+    Version: {
+      Version: '5.0.0',
+    },
+  };
+
+  vi.spyOn(extensionApi.process, 'exec').mockReturnValue(
+    Promise.resolve({ stdout: JSON.stringify(fakeMachineInfoJSON) } as extensionApi.RunResult),
+  );
+
+  // Mock existsSync to return true (the "fake" file is there)
+  vi.mock('node:fs');
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+  // Mock the readFile function to return the "fake" file with rootful being true
+  vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce(JSON.stringify({ HostUser: { Rootful: true } }));
+  await expect(machineUtils.isPodmanMachineRootful()).resolves.toBe(true);
+
+  expect(await machineUtils.checkPrereqs()).toEqual(undefined);
 });

--- a/packages/backend/src/machine-utils.ts
+++ b/packages/backend/src/machine-utils.ts
@@ -96,6 +96,19 @@ export async function isPodmanV5Machine() {
   }
 }
 
+export async function checkPrereqs(): Promise<string | undefined> {
+  const isPodmanV5 = await isPodmanV5Machine();
+  if (!isPodmanV5) {
+    return 'Podman v5.0 or higher is required to build disk images.';
+  }
+
+  const isRootful = await isPodmanMachineRootful();
+  if (!isRootful) {
+    return 'The podman machine is not set as rootful. Please recreate the podman machine with rootful privileges set and try again.';
+  }
+  return undefined;
+}
+
 // Below functions are borrowed from the podman extension
 function getPodmanCli(): string {
   const customBinaryPath = getCustomBinaryPath();

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -16,11 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  l***********************************************************************/
 
-import type { BootcBuildInfo } from './models/bootc';
+import type { BootcBuildInfo, BuildType } from './models/bootc';
 import type { ImageInfo } from '@podman-desktop/api';
 
 export abstract class BootcApi {
-  abstract buildImage(build: BootcBuildInfo): Promise<void>;
+  abstract checkPrereqs(): Promise<string | undefined>;
+  abstract buildExists(folder: string, types: BuildType[]): Promise<boolean>;
+  abstract buildImage(build: BootcBuildInfo, overwrite?: boolean): Promise<void>;
   abstract pullImage(image: string): Promise<void>;
   abstract deleteBuilds(builds: BootcBuildInfo[]): Promise<void>;
   abstract selectOutputFolder(): Promise<string>;


### PR DESCRIPTION
### What does this PR do?

Currently, there is no way for the frontend to check prereqs or see if there is an existing image before attempting to build, at which point the backend has to open dialogs to notify of an error, or ask the user whether to overwrite.

This PR moves the existing code from the build to check prereqs and for existing images out into two functions accessible to the frontend:
 - checkPrereq() checks that the machine is Podman v5 and rootful.
 - buildExists() checks if there's an existing build in a given folder.

It also adds an option to the build to overwrite an existing image.

Tests existed for the underlying function and the build just calls the refactored functions, so there is no behaviour change from before.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Refactoring in preparation for #200 and #262.

### How to test this PR?

Existing PR checks and Build page works as before.