### PR TITLE
chore: increase build timeout

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -11,7 +11,18 @@
   },
   "main": "./dist/extension.js",
   "contributes": {
-    "configuration": {},
+    "configuration": {
+      "title": "Bootable Containers",
+      "properties": {
+        "bootc.build.timeout": {
+          "type": "number",
+          "minimum": 1,
+          "default": 30,
+          "maximum": 120,
+          "description": "Build timeout (in minutes)"
+        }
+      }
+    },
     "menus": {
       "dashboard/image": [
         {

--- a/packages/backend/src/container-utils.spec.ts
+++ b/packages/backend/src/container-utils.spec.ts
@@ -52,10 +52,14 @@ vi.mock('@podman-desktop/api', async () => {
         },
       ]),
     },
-    env: {
-      createTelemetryLogger: () => ({
-        logUsage: mocks.logUsageMock,
-      }),
+  };
+});
+
+vi.mock('./extension', async () => {
+  return {
+    getConfigurationValue: vi.fn(),
+    telemetryLogger: {
+      logUsage: mocks.logUsageMock,
     },
   };
 });

--- a/packages/backend/src/container-utils.ts
+++ b/packages/backend/src/container-utils.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import type { ContainerCreateOptions } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
-import { telemetryLogger } from './extension';
+import { getConfigurationValue, telemetryLogger } from './extension';
 
 // Get the running container engine
 export async function getContainerEngine(): Promise<extensionApi.ContainerProviderConnection> {
@@ -130,13 +130,10 @@ export async function createAndStartContainer(engineId: string, options: Contain
   }
 }
 
-export async function waitForContainerToExit(
-  containerId: string,
-  maxRetryCount: number = 5,
-  timeoutMinutes: number = 10,
-): Promise<void> {
+export async function waitForContainerToExit(containerId: string, maxRetryCount: number = 5): Promise<void> {
   let retryCount = 0;
   let containerRunning = true;
+  const timeoutMinutes = (await getConfigurationValue<number>('build.timeout')) ?? 60;
   const timeout = timeoutMinutes * 60 * 1000; // change to minutes
 
   const timeoutPromise = new Promise((_, reject) =>

--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -149,6 +149,10 @@ export async function openBuildPage(
   });
 }
 
+export async function getConfigurationValue<T>(property: string) {
+  return extensionApi.configuration.getConfiguration('bootc').get<T>(property);
+}
+
 export async function deactivate(): Promise<void> {
   console.log('stopping bootc extension');
 }


### PR DESCRIPTION
### What does this PR do?

Makes the build timeout a configurable timeout in Settings > Preferences.
Adds a helper function in extension.ts for future configuration, and increases the default timeout to 30 minutes.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #315.

### How to test this PR?

Create a really big image/slow your machine down, or set the timeout really low.