### PR TITLE
feat: build form validation

### DIFF
--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -20,7 +20,7 @@ import * as podmanDesktopApi from '@podman-desktop/api';
 import type { ImageInfo } from '@podman-desktop/api';
 import type { BootcApi } from '/@shared/src/BootcAPI';
 import type { BootcBuildInfo, BuildType } from '/@shared/src/models/bootc';
-import { buildDiskImage } from './build-disk-image';
+import { buildDiskImage, buildExists } from './build-disk-image';
 import { History } from './history';
 import * as containerUtils from './container-utils';
 import { Messages } from '/@shared/src/messages/Messages';
@@ -44,7 +44,7 @@ export class BootcApiImpl implements BootcApi {
   }
 
   async buildExists(folder: string, types: BuildType[]): Promise<boolean> {
-    return this.buildExists(folder, types);
+    return buildExists(folder, types);
   }
 
   async buildImage(build: BootcBuildInfo, overwrite?: boolean): Promise<void> {

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -139,7 +139,7 @@ async function buildBootcImage() {
     // the reason being is that the validation / error logic happens in buildDiskImage
     // in the backend and it will error out there as that is where we can console.log
     // as well as notify the user of the error via showErrorMessage / showInformationMessage, etc.
-    bootcClient.buildImage(buildOptions, overwrite || true); // TODO
+    bootcClient.buildImage(buildOptions, overwrite);
 
     // Continue doing listHistoryInfo until the build container name, tag, type and arch show up
     // this means we can safely exit and see it in the dashboard as it's now in the history / running in the background.

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -100,7 +100,6 @@ async function validate() {
 
   // overwrite
   existingBuild = await bootcClient.buildExists(buildFolder, buildType);
-  console.log('existing: ' + existingBuild + ' ' + overwrite);
   if (existingBuild && !overwrite) {
     errorFormValidation = 'Confirm overwriting existing build';
     return;
@@ -111,6 +110,12 @@ async function validate() {
 }
 
 async function buildBootcImage() {
+  // you can't get here without a selected image, but this
+  // avoids a svelte error
+  if (!selectedImage) {
+    return;
+  }
+
   // Before building a disk image name, we get a unique unused identifier for this image
   // This is to prevent the user from accidentally overwriting an history
   const buildImageName = selectedImage.split(':')[0];
@@ -122,7 +127,7 @@ async function buildBootcImage() {
     id: buildID,
     image: buildImageName,
     tag: selectedImage.split(':')[1],
-    engineId: image?.engineId,
+    engineId: image?.engineId ?? '',
     folder: buildFolder,
     type: buildType,
     arch: buildArch,
@@ -435,7 +440,8 @@ $: if (selectedImage || buildFolder || buildType || buildArch || overwrite) {
         {#if buildInProgress}
           <Button class="w-full" disabled="{true}">Creating build task</Button>
         {:else}
-          <Button on:click="{() => buildBootcImage()}" disabled="{errorFormValidation}" class="w-full">Build</Button>
+          <Button on:click="{() => buildBootcImage()}" disabled="{errorFormValidation != undefined}" class="w-full"
+            >Build</Button>
         {/if}
       </div>
     {/if}


### PR DESCRIPTION
### What does this PR do?

Prior to this change, if you were missing prereqs (v5+rootful) or were missing some option you wouldn't see a problem until you build, and then after you accepted the error message it would sit on the build screen for 10s before it timed out. Likewise, if there was an existing build and you said 'no' to overwriting, it would wait for 10s to time out.

With this change, all validation is done inside the form. If you're missing a prereq or one of the options, the error message is visible at the bottom of the form and the Build button is disabled until you fix it. If you need to confirm overwriting an existing build, a checkbox appears.

Renamed buildErrorMessage so it's more clear this is the post-build error.

Added tests for prereqs and overwriting, and fixed the rather obvious error in api-impl.ts.

### Screenshot / video of UI

https://github.com/containers/podman-desktop-extension-bootc/assets/19958075/761049ef-f13a-47a0-b7b0-848ccc033ac7

### What issues does this PR fix or reference?

Fixes #262. Fixes #200.

### How to test this PR?

Automated tests added. For manual testing, try without one of the prereqs (e.g. podman 4.9 or non-rootful, or with missing info in the form.