### PR TITLE
chore: fix vmdk output folder

### DIFF
--- a/packages/backend/src/build-disk-image.spec.ts
+++ b/packages/backend/src/build-disk-image.spec.ts
@@ -136,7 +136,7 @@ test('check build exists', async () => {
   const folder = '/output';
 
   // mock two existing builds on disk: qcow2 and vmdk
-  const existsList: string[] = [resolve(folder, 'qcow2/disk.qcow2'), resolve(folder, 'image/disk.vmdk')];
+  const existsList: string[] = [resolve(folder, 'qcow2/disk.qcow2'), resolve(folder, 'vmdk/disk.vmdk')];
   vi.mock('node:fs');
   vi.spyOn(fs, 'existsSync').mockImplementation(f => {
     return existsList.includes(f.toString());

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -38,7 +38,7 @@ export async function buildExists(folder: string, types: BuildType[]) {
     } else if (type === 'raw') {
       imageName = 'image/disk.raw';
     } else if (type === 'vmdk') {
-      imageName = 'image/disk.vmdk';
+      imageName = 'vmdk/disk.vmdk';
     } else if (type === 'iso') {
       imageName = 'bootiso/disk.iso';
     }


### PR DESCRIPTION
### What does this PR do?

I noticed during testing that the path where vmdk images are generated is wrong, or was changed at some point. We don't prompt to overwrite without this change.

At some point our E2E tests will be able to cover this.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Generate a vmdk build, then a second one. You won't be prompted to confirm overwriting before this change.