### PR TITLE
chore: consistent titles

### DIFF
--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -238,7 +238,7 @@ $: if (selectedImage || buildFolder || buildType || buildArch || overwrite) {
       <div class="bg-charcoal-900 pt-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg">
         <div class="{buildInProgress ? 'opacity-40 pointer-events-none' : ''}">
           <div class="pb-4">
-            <label for="modalImageTag" class="block mb-2 text-sm font-medium text-gray-400">Image tag</label>
+            <label for="modalImageTag" class="block mb-2 text-md font-semibold">Image to build</label>
             <div class="relative">
               <!-- Container with relative positioning -->
               <select
@@ -278,7 +278,7 @@ $: if (selectedImage || buildFolder || buildType || buildArch || overwrite) {
             {/if}
           </div>
           <div>
-            <label for="path" class="block mb-2 text-sm font-bold text-gray-400">Build output folder</label>
+            <label for="path" class="block mb-2 text-md font-semibold">Build output folder</label>
             <div class="flex flex-row space-x-3">
               <Input
                 name="path"


### PR DESCRIPTION
### What does this PR do?

The first two titles had different styling than the others, this just makes them match.

### Screenshot / video of UI

Before:
<img width="305" alt="Screenshot 2024-04-12 at 12 19 33 PM" src="https://github.com/containers/podman-desktop-extension-bootc/assets/19958075/a28f1d33-56ba-4a17-872c-22201800eb8c">

After:
<img width="305" alt="Screenshot 2024-04-12 at 12 14 25 PM" src="https://github.com/containers/podman-desktop-extension-bootc/assets/19958075/375ca626-cbf3-46c1-8542-388956297578">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Open build page.