### PR TITLE
chore(tests): update test framework used when running e2e tests

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -101,6 +101,10 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      
+      - name: Ensure getting current HEAD version of the test framework
+        working-directory: ./podman-desktop-extension-bootc/tests/playwright
+        run: yarn add -D @podman-desktop/tests-playwright@next
 
       - name: Execute yarn in Bootc Extension
         working-directory: ./podman-desktop-extension-bootc


### PR DESCRIPTION
### What does this PR do?
Updates the test framework before running e2e tests after merging to main.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-extension-bootc/issues/336
