### PR TITLE
feat: add inspectManifest endpoint to api

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -86,7 +86,7 @@
     "watch": "vite --mode development build -w"
   },
   "devDependencies": {
-    "@podman-desktop/api": "1.9.1",
+    "@podman-desktop/api": "0.0.202404191551-0a47d08",
     "@types/node": "^20",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^6.16.0",

--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -126,6 +126,21 @@ export class BootcApiImpl implements BootcApi {
     return imageInspect;
   }
 
+  // We pass in imageInfo because when we do listImages, it also lists manifests, and we can use imageInfo to get the manifest
+  // name and engineId required.
+  async inspectManifest(image: ImageInfo): Promise<podmanDesktopApi.ManifestInspectInfo> {
+    let manifestInspect: podmanDesktopApi.ManifestInspectInfo;
+    try {
+      manifestInspect = await podmanDesktopApi.containerEngine.inspectManifest(image.engineId, image.Id);
+    } catch (err) {
+      throw new Error(`Error inspecting manifest: ${err}`);
+    }
+    if (manifestInspect === undefined) {
+      throw new Error('Unable to retrieve manifest inspect information');
+    }
+    return manifestInspect;
+  }
+
   async listHistoryInfo(): Promise<BootcBuildInfo[]> {
     try {
       // Load the file so it retrieves the latest information.

--- a/packages/backend/src/container-utils.ts
+++ b/packages/backend/src/container-utils.ts
@@ -56,6 +56,17 @@ export async function inspectImage(engineId: string, image: string): Promise<ext
   }
 }
 
+// Inspect a manifest
+export async function inspectManifest(engineId: string, image: string): Promise<extensionApi.ManifestInspectInfo> {
+  console.log('Inspecting manifest: ', image);
+  try {
+    return await extensionApi.containerEngine.inspectManifest(engineId, image);
+  } catch (e) {
+    console.error(e);
+    throw new Error('There was an error inspecting the manifest: ' + e);
+  }
+}
+
 // Pull the image
 export async function pullImage(image: string) {
   const telemetryData: Record<string, unknown> = {};

--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -60,6 +60,7 @@ const mockBootcImages: ImageInfo[] = [
     Size: 0,
     Containers: 0,
     SharedSize: 0,
+    Digest: 'sha256:image1',
   },
   {
     Id: 'image2',
@@ -75,6 +76,7 @@ const mockBootcImages: ImageInfo[] = [
     Size: 0,
     Containers: 0,
     SharedSize: 0,
+    Digest: 'sha256:image2',
   },
 ];
 

--- a/packages/frontend/src/lib/BootcEmptyScreen.spec.ts
+++ b/packages/frontend/src/lib/BootcEmptyScreen.spec.ts
@@ -41,6 +41,7 @@ const mockBootcImages: ImageInfo[] = [
     Size: 0,
     Containers: 0,
     SharedSize: 0,
+    Digest: 'sha256:1234567890abcdef',
   },
 ];
 

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -17,7 +17,7 @@
  l***********************************************************************/
 
 import type { BootcBuildInfo, BuildType } from './models/bootc';
-import type { ImageInfo, ImageInspectInfo } from '@podman-desktop/api';
+import type { ImageInfo, ImageInspectInfo, ManifestInspectInfo } from '@podman-desktop/api';
 
 export abstract class BootcApi {
   abstract checkPrereqs(): Promise<string | undefined>;
@@ -25,6 +25,7 @@ export abstract class BootcApi {
   abstract buildImage(build: BootcBuildInfo, overwrite?: boolean): Promise<void>;
   abstract pullImage(image: string): Promise<void>;
   abstract inspectImage(image: ImageInfo): Promise<ImageInspectInfo>;
+  abstract inspectManifest(image: ImageInfo): Promise<ManifestInspectInfo>;
   abstract deleteBuilds(builds: BootcBuildInfo[]): Promise<void>;
   abstract selectOutputFolder(): Promise<string>;
   abstract listBootcImages(): Promise<ImageInfo[]>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -387,10 +387,10 @@
   dependencies:
     playwright "1.42.1"
 
-"@podman-desktop/api@1.9.1":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-1.9.1.tgz#2735cf2cd05532bf6758ebf33c7c579b2beb444d"
-  integrity sha512-AO4yB7JerfZNhmpPnBMwIZ+pNWaJRg+GtqOkEW97VxoyrZ2jsZOk28XefdJI/4xa8xF1cWfxjET9W29Z4tztGA==
+"@podman-desktop/api@0.0.202404191551-0a47d08":
+  version "0.0.202404191551-0a47d08"
+  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-0.0.202404191551-0a47d08.tgz#178becbc805e79e3ba7ac90161c1c399b843d5e3"
+  integrity sha512-2dL8HZHP/JDZRF6PHIb7wrksuT8/PTALCcfR9Ze/Tqp6OAaHsZA6zNGEo4wS280ZZEkxw10Vohi3yR70UAZnWg==
 
 "@podman-desktop/tests-playwright@^1.9.1":
   version "1.9.1"
@@ -3898,16 +3898,7 @@ stop-iteration-iterator@^1.0.0:
   dependencies:
     internal-slot "^1.0.4"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3953,14 +3944,7 @@ string.prototype.trimstart@^1.0.7:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4545,16 +4529,7 @@ why-is-node-running@^2.2.2:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
feat: add inspectManifest endpoint to api

### What does this PR do?

* Adds the inspectManifest endpoint to the API
* Requires https://github.com/containers/podman-desktop/pull/6812 to go in
first

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/340

### How to test this PR?

Use the `inspectManifest` endpoint with a passed in image.

<!-- Please explain steps to reproduce -->
