### PR TITLE
nit: make red colouring less bright

### DIFF
--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -435,7 +435,7 @@ $: if (selectedImage || buildFolder || buildType || buildArch || overwrite) {
           </label>
         {/if}
         {#if errorFormValidation}
-          <div aria-label="validation" class="bg-red-600 p-3 rounded-md text-white text-sm">{errorFormValidation}</div>
+          <div aria-label="validation" class="bg-red-800 p-3 rounded-md text-white text-sm">{errorFormValidation}</div>
         {/if}
         {#if buildInProgress}
           <Button class="w-full" disabled="{true}">Creating build task</Button>


### PR DESCRIPTION
nit: make red colouring less bright

### What does this PR do?

It's hurting my sensitive eyeballs.

I find the bright red very distracting and it'd be good to have it
darker similar to PD.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

New:

![Screenshot 2024-04-16 at 10 00 47 AM](https://github.com/containers/podman-desktop-extension-bootc/assets/6422176/c67a46d1-4a92-4efd-a21b-061ff4718377)

Old:
![Screenshot 2024-04-16 at 10 02 58 AM](https://github.com/containers/podman-desktop-extension-bootc/assets/6422176/18ec1f2a-fe03-4a09-985c-4ecc47aa73b7)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

Preview the UI

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
