### PR TITLE
feat: add manifest / multi-arch selection support

### DIFF
--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -18,4 +18,4 @@
 
 // Image related
 export const bootcImageBuilderContainerName = '-bootc-image-builder';
-export const bootcImageBuilderName = 'quay.io/centos-bootc/bootc-image-builder:latest-1713548482';
+export const bootcImageBuilderName = 'quay.io/centos-bootc/bootc-image-builder:latest-1714169595';


### PR DESCRIPTION
feat: add manifest / multi-arch selection support

### What does this PR do?

* Manifests are now listed, inspected and propagated within the Build
  page
* Simply select a manifest, select the arch and it will build

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/containers/podman-desktop-extension-bootc/assets/6422176/5a2c32a2-cddc-4180-9758-c7512d48bbf8


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/324

### How to test this PR?

<!-- Please explain steps to reproduce -->

Follow the video above, or do the following tests:

1. Build a manifest within Podman Desktop (select two architectures, and
   build a bootc image). Must use the latest Podman Desktop
2. Select the manifest within the extension and see it build.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
