### PR TITLE
chore: send telemetry on startup

### DIFF
--- a/packages/backend/src/extension.spec.ts
+++ b/packages/backend/src/extension.spec.ts
@@ -26,6 +26,7 @@ import os from 'node:os';
 const originalConsoleLog = console.log;
 
 const mocks = vi.hoisted(() => ({
+  logUsageMock: vi.fn(),
   logErrorMock: vi.fn(),
   consoleLogMock: vi.fn(),
   consoleWarnMock: vi.fn(),
@@ -42,7 +43,7 @@ vi.mock('@podman-desktop/api', async () => {
     version: '1.8.0',
     env: {
       createTelemetryLogger: () => ({
-        logUsage: vi.fn(),
+        logUsage: mocks.logUsageMock,
         logError: mocks.logErrorMock,
       }),
     },
@@ -106,6 +107,7 @@ test('check activate', async () => {
   await activate(fakeContext);
 
   expect(mocks.consoleLogMock).toBeCalledWith('starting bootc extension');
+  expect(mocks.logUsageMock).toHaveBeenCalled();
 });
 
 describe('version checker', () => {

--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -45,9 +45,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     );
   }
 
-  telemetryLogger.logUsage('start', {
-    version: version,
-  });
+  telemetryLogger.logUsage('start');
 
   const history = new History(extensionContext.storagePath);
   await history.loadFile();

--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -45,6 +45,10 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     );
   }
 
+  telemetryLogger.logUsage('start', {
+    version: version,
+  });
+
   const history = new History(extensionContext.storagePath);
   await history.loadFile();
 


### PR DESCRIPTION
### What does this PR do?

I noticed that AI lab is doing this - send the extension version in on startup so that we can see which version users have installed. This should also be in the PD telemetry, but easier to track/correlate here.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Test updated.