### PR TITLE
chore: remove bib iso target workaround

### DIFF
--- a/packages/backend/src/build-disk-image.spec.ts
+++ b/packages/backend/src/build-disk-image.spec.ts
@@ -100,8 +100,7 @@ test('check image builder does not include target arch', async () => {
   expect(options.Cmd).not.toContain('--target-arch');
 });
 
-// temporary test, see createBuilderImageOptions
-test('temporarily check image builder does not include target arch for iso', async () => {
+test('check image builder includes target arch for iso', async () => {
   const image = 'test-image';
   const type = 'iso';
   const arch = 'amd';
@@ -110,7 +109,7 @@ test('temporarily check image builder does not include target arch for iso', asy
   const options = createBuilderImageOptions(name, image, [type], arch, outputFolder);
 
   expect(options).toBeDefined();
-  expect(options.Cmd).not.toContain('--target-arch');
+  expect(options.Cmd).toContain('--target-arch');
 });
 
 test('check we pick unused container name', async () => {

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -322,12 +322,7 @@ export function createBuilderImageOptions(
 
   type.forEach(t => cmd.push('--type', t));
 
-  // bootc image builder does not currently support specifying a target arch
-  // (even the current/default one) when building an iso. Enough people are
-  // hitting this that we are putting in a temporary workaround until the
-  // following issue is resolved:
-  // https://github.com/osbuild/bootc-image-builder/issues/316
-  if (arch && !type.find(buildType => buildType === 'iso')) {
+  if (arch) {
     cmd.push('--target-arch', arch);
   }
 


### PR DESCRIPTION
### What does this PR do?

Bootc image builder does not support cross-arch building of ISO images for now: https://github.com/osbuild/bootc-image-builder/issues/316

However, there was an issue where it would fail if you specify a target arch, even if that's the current one. This has been fixed and is in the bib that we currently depend on: https://github.com/osbuild/bootc-image-builder/pull/364

This removes the workaround we had in place to avoid ISO builds failing.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #269.

### How to test this PR?

Unit test updated. Build any iso to confirm it now works.