### PR TITLE
chore: use disk image after starting build

### DIFF
--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import './app.css';
-import { faCube, faQuestionCircle, faRocket, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { faCube, faQuestionCircle, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { bootcClient } from './api/client';
 import FormPage from './lib/upstream/FormPage.svelte';
 import Button from './lib/upstream/Button.svelte';
@@ -270,7 +270,7 @@ $: if (availableArchitectures) {
   <div slot="content" class="p-5 min-w-full h-fit">
     {#if success}
       <EmptyScreen
-        icon="{faRocket}"
+        icon="{DiskImageIcon}"
         title="Build task started"
         message="Check your progress by viewing the build container, or clicking the tasks button in the bottom right corner of Podman Desktop.">
         <Button


### PR DESCRIPTION
### What does this PR do?

Just a little thing I noticed this morning, after clicking Build we should show the Disk Image icon, not rocket.

### Screenshot / video of UI

<img width="1162" alt="Screenshot 2024-04-25 at 1 55 30 PM" src="https://github.com/containers/podman-desktop-extension-bootc/assets/19958075/0c98efa4-92d0-43d9-9f73-af359769ec87">

### What issues does this PR fix or reference?

Fixes #390.

### How to test this PR?

Build an image.