### PR TITLE
fix: make correct import of Podman Desktop ui svelte library

### DIFF
--- a/packages/frontend/tailwind.config.cjs
+++ b/packages/frontend/tailwind.config.cjs
@@ -23,7 +23,7 @@ module.exports = {
   content: [
     'index.html',
     'src/**/*.{svelte,ts,css}',
-    'node_modules/@podman-desktop/ui-svelte/src/**/*.{svelte,ts,css}',
+    '../../node_modules/@podman-desktop/ui-svelte/src/**/*.{svelte,ts,css}',
   ],
   darkMode: 'class',
   theme: {


### PR DESCRIPTION
### What does this PR do?
Fixes the import of svelte components from 3rd party library

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop-extension-bootc/assets/436777/cb2353f8-9661-421c-83eb-145420fb8bcf)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop-extension-bootc/issues/292

### How to test this PR?

<!-- Please explain steps to reproduce -->
