### PR TITLE
fix: remove the usage of the MontSerrat font

### DIFF
--- a/packages/frontend/tailwind.config.cjs
+++ b/packages/frontend/tailwind.config.cjs
@@ -44,9 +44,6 @@ module.exports = {
         'leftnavbar': '54px',
         'leftsidebar': '225px',
       },
-      fontFamily: {
-        sans: ['Montserrat', ...defaultTheme.fontFamily.sans],
-      },
       typography: (theme) => ({
         DEFAULT: {
           css: {


### PR DESCRIPTION
### What does this PR do?
it's only used in the website of Podman Desktop so it makes the UI not consistent with Podman Desktop

### Screenshot / video of UI

Pages of bootc extension will look more similar than Podman Desktop core

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
