### PR TITLE
chore: update containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -29,6 +29,6 @@ FROM scratch
 LABEL org.opencontainers.image.title="Bootable Container Extension" \
         org.opencontainers.image.description="Podman Desktop extension for bootable OS containers (bootc) and generating disk images" \
         org.opencontainers.image.vendor="Red Hat" \
-        io.podman-desktop.api.version=">= 1.8.0"
+        io.podman-desktop.api.version=">= 1.10.0"
 
 COPY --from=builder /extension /extension


### PR DESCRIPTION
### What does this PR do?

Our startup check would block use on wrong version of Podman Desktop anyway, but best to keep all metadata in sync and now clearly depending on 1.10.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #404.

### How to test this PR?

Just PR checks for now.