### PR TITLE
chore: update bootc-image-builder (includes iso fix)

### DIFF
--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -18,4 +18,4 @@
 
 // Image related
 export const bootcImageBuilderContainerName = '-bootc-image-builder';
-export const bootcImageBuilderName = 'quay.io/centos-bootc/bootc-image-builder:latest-1714169595';
+export const bootcImageBuilderName = 'quay.io/centos-bootc/bootc-image-builder:latest-1714474808';


### PR DESCRIPTION
chore: update bootc-image-builder (includes iso fix)

### What does this PR do?

Updates to the newest bib image which includes the ISO fix: https://github.com/osbuild/bootc-image-builder/issues/404

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

https://github.com/osbuild/bootc-image-builder/issues/404

### How to test this PR?

<!-- Please explain steps to reproduce -->

You can test this by building a manifest, then selecting an iso (amd64
or arm64) and booting it with your favourite VM manager.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
