### PR TITLE
feat: add ability to select default, xfs and ext4 filesystem

### DIFF
--- a/packages/backend/src/build-disk-image.spec.ts
+++ b/packages/backend/src/build-disk-image.spec.ts
@@ -46,7 +46,7 @@ test('check image builder options', async () => {
   const arch = 'amd';
   const name = 'my-image';
   const outputFolder = '/output-folder';
-  const options = createBuilderImageOptions(name, image, [type], arch, outputFolder);
+  const options = createBuilderImageOptions(name, image, [type], arch, outputFolder, undefined);
 
   expect(options).toBeDefined();
   expect(options.name).toEqual(name);
@@ -65,7 +65,7 @@ test('check image builder with multiple types', async () => {
   const arch = 'amd';
   const name = 'my-image';
   const outputFolder = '/output-folder';
-  const options = createBuilderImageOptions(name, image, type, arch, outputFolder);
+  const options = createBuilderImageOptions(name, image, type, arch, outputFolder, undefined);
 
   expect(options).toBeDefined();
   expect(options.name).toEqual(name);
@@ -94,7 +94,7 @@ test('check image builder does not include target arch', async () => {
   const type = 'vmdk';
   const name = 'my-image';
   const outputFolder = '/output-folder';
-  const options = createBuilderImageOptions(name, image, [type], undefined, outputFolder);
+  const options = createBuilderImageOptions(name, image, [type], undefined, outputFolder, undefined);
 
   expect(options).toBeDefined();
   expect(options.Cmd).not.toContain('--target-arch');
@@ -106,10 +106,64 @@ test('check image builder includes target arch for iso', async () => {
   const arch = 'amd';
   const name = 'my-image';
   const outputFolder = '/output-folder';
-  const options = createBuilderImageOptions(name, image, [type], arch, outputFolder);
+  const options = createBuilderImageOptions(name, image, [type], arch, outputFolder, undefined);
 
   expect(options).toBeDefined();
   expect(options.Cmd).toContain('--target-arch');
+});
+
+test('check that if xfs is passed into filesystem, it is included in the command', async () => {
+  const image = 'test-image';
+  const type = 'vmdk';
+  const arch = 'amd';
+  const name = 'my-image';
+  const outputFolder = '/output-folder';
+  const filesystem = 'xfs';
+  const options = createBuilderImageOptions(name, image, [type], arch, outputFolder, filesystem);
+
+  expect(options).toBeDefined();
+  expect(options.Cmd).toContain('--rootfs');
+  expect(options.Cmd).toContain(filesystem);
+});
+
+test('check that if ext4 is passed into the filesystem, it is included in the command', async () => {
+  const image = 'test-image';
+  const type = 'vmdk';
+  const arch = 'amd';
+  const name = 'my-image';
+  const outputFolder = '/output-folder';
+  const filesystem = 'ext4';
+  const options = createBuilderImageOptions(name, image, [type], arch, outputFolder, filesystem);
+
+  expect(options).toBeDefined();
+  expect(options.Cmd).toContain('--rootfs');
+  expect(options.Cmd).toContain(filesystem);
+});
+
+test('test if a fake filesystem foobar is passed into filesystem, it is not included in the command', async () => {
+  const image = 'test-image';
+  const type = 'vmdk';
+  const arch = 'amd';
+  const name = 'my-image';
+  const outputFolder = '/output-folder';
+  const filesystem = 'foobar';
+  const options = createBuilderImageOptions(name, image, [type], arch, outputFolder, filesystem);
+
+  expect(options).toBeDefined();
+  expect(options.Cmd).not.toContain('--rootfs');
+});
+
+test('test if blank string is passed into filesystem, it is not included in the command', async () => {
+  const image = 'test-image';
+  const type = 'vmdk';
+  const arch = 'amd';
+  const name = 'my-image';
+  const outputFolder = '/output-folder';
+  const filesystem = '';
+  const options = createBuilderImageOptions(name, image, [type], arch, outputFolder, filesystem);
+
+  expect(options).toBeDefined();
+  expect(options.Cmd).not.toContain('--rootfs');
 });
 
 test('check we pick unused container name', async () => {

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -128,6 +128,7 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History, ov
           build.type,
           build.arch,
           build.folder,
+          build.filesystem,
         );
         logData += JSON.stringify(buildImageContainer, undefined, 2);
         logData += '\n----------\n';
@@ -317,6 +318,7 @@ export function createBuilderImageOptions(
   type: BuildType[],
   arch: string | undefined,
   folder: string,
+  filesystem: string | undefined,
 ): ContainerCreateOptions {
   const cmd = [image, '--output', '/output/', '--local'];
 
@@ -324,6 +326,12 @@ export function createBuilderImageOptions(
 
   if (arch) {
     cmd.push('--target-arch', arch);
+  }
+
+  // If the filesystem is specified, add it to the command
+  // the only available options are 'ext4' and 'xfs', check that filesystem is not undefined and is one of the two options
+  if (filesystem && (filesystem === 'ext4' || filesystem === 'xfs')) {
+    cmd.push('--rootfs', filesystem);
   }
 
   // Create the image options for the "bootc-image-builder" container

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -18,4 +18,4 @@
 
 // Image related
 export const bootcImageBuilderContainerName = '-bootc-image-builder';
-export const bootcImageBuilderName = 'quay.io/centos-bootc/bootc-image-builder:latest-1714474808';
+export const bootcImageBuilderName = 'quay.io/centos-bootc/bootc-image-builder:latest-1714633180';

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -32,6 +32,7 @@ let availableArchitectures: string[] = [];
 let buildFolder: string;
 let buildType: BuildType[] = [];
 let buildArch: string | undefined;
+let buildFilesystem: string = ''; // Default filesystem auto-selected / empty
 let overwrite: boolean = false;
 
 // Other variable
@@ -157,6 +158,7 @@ async function buildBootcImage() {
     folder: buildFolder,
     type: buildType,
     arch: buildArch,
+    filesystem: buildFilesystem,
   };
 
   buildInProgress = true;
@@ -368,7 +370,7 @@ $: if (availableArchitectures) {
               <Button on:click="{() => getPath()}">Browse...</Button>
             </div>
           </div>
-          <div class="pt-3 space-y-7 h-fit">
+          <div class="pt-3 space-y-3 h-fit">
             <div class="mb-2">
               <span class="text-md font-semibold mb-2 block">Disk image type</span>
               <div class="flex items-center mb-3">
@@ -466,6 +468,57 @@ $: if (availableArchitectures) {
                   <span class="text-sm text-white">Amazon Machine Image (*.ami)</span>
                 </label>
               </div>
+            </div>
+            <div>
+              <span class="text-md font-semibold mb-2 block">Filesystem</span>
+              <div class="flex items-center mb-3 space-x-3">
+                <label for="defaultFs" class="ml-1 flex items-center cursor-pointer">
+                  <input
+                    bind:group="{buildFilesystem}"
+                    type="radio"
+                    id="defaultFs"
+                    name="filesystem"
+                    value=""
+                    class="sr-only peer"
+                    aria-label="default-filesystem-select" />
+                  <div
+                    class="w-4 h-4 rounded-full border-2 border-gray-400 mr-2 peer-checked:border-purple-500 peer-checked:bg-purple-500">
+                  </div>
+                  <span class="text-sm text-white">Default</span>
+                </label>
+                <label for="xfsFs" class="ml-1 flex items-center cursor-pointer">
+                  <input
+                    bind:group="{buildFilesystem}"
+                    type="radio"
+                    id="xfsFs"
+                    name="filesystem"
+                    value="xfs"
+                    class="sr-only peer"
+                    aria-label="xfs-filesystem-select" />
+                  <div
+                    class="w-4 h-4 rounded-full border-2 border-gray-400 mr-2 peer-checked:border-purple-500 peer-checked:bg-purple-500">
+                  </div>
+                  <span class="text-sm text-white">XFS</span>
+                </label>
+                <label for="ext4Fs" class="ml-1 flex items-center cursor-pointer">
+                  <input
+                    bind:group="{buildFilesystem}"
+                    type="radio"
+                    id="ext4Fs"
+                    name="filesystem"
+                    value="ext4"
+                    class="sr-only peer"
+                    aria-label="ext4-filesystem-select" />
+                  <div
+                    class="w-4 h-4 rounded-full border-2 border-gray-400 mr-2 peer-checked:border-purple-500 peer-checked:bg-purple-500">
+                  </div>
+                  <span class="text-sm text-white">EXT4</span>
+                </label>
+              </div>
+              <p class="text-gray-300 text-xs">
+                Note: The default filesystem is automatically detected based on the base container image. However, some
+                images such as Fedora may require a specific filesystem to be selected.
+              </p>
             </div>
             <div class="mb-2">
               <span class="text-md font-semibold mb-2 block">Platform</span>

--- a/packages/shared/src/models/bootc.ts
+++ b/packages/shared/src/models/bootc.ts
@@ -25,6 +25,7 @@ export interface BootcBuildInfo {
   engineId: string;
   type: BuildType[];
   folder: string;
+  filesystem?: string;
   arch?: string;
   status?: BootcBuildStatus;
   timestamp?: string;


### PR DESCRIPTION
feat: add ability to select default, xfs and ext4 filesystem

### What does this PR do?

* Ability to select the filesystem by either picking default (which will
  use the container's default), xfs or ext4.
* Updates the bootc-image-builder image to support rootfs

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2024-05-02 at 3 32 45 PM](https://github.com/containers/podman-desktop-extension-bootc/assets/6422176/96face55-ec38-41c1-a641-4b63baad5873)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/433

### How to test this PR?

<!-- Please explain steps to reproduce -->

Normal testing:
1. Go through all the normal build scenarios (build manifest, etc) and
   select the either default, xfs or ext4.

Testing Fedora:
1. Pull `quay.io/fedora/fedora-bootc:40`
2. Build `quay.io/fedora/fedora-bootc:40` and select "default" it should
   fail.
3. Build `quay.io/fedora/fedora-bootc:40` and select "xfs" or "ext4" and
   it should build.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
