### PR TITLE
feature: detect fedora image and update filesystem

### DIFF
--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -97,6 +97,17 @@ export class BootcApiImpl implements BootcApi {
     return '';
   }
 
+  async listAllImages(): Promise<ImageInfo[]> {
+    let images: ImageInfo[] = [];
+    try {
+      images = await podmanDesktopApi.containerEngine.listImages();
+    } catch (err) {
+      await podmanDesktopApi.window.showErrorMessage(`Error listing images: ${err}`);
+      console.error('Error listing images: ', err);
+    }
+    return images;
+  }
+
   async listBootcImages(): Promise<ImageInfo[]> {
     let images: ImageInfo[] = [];
     try {

--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -642,3 +642,57 @@ test('have amd64 and arm64 NOT disabled (opacity-50) if inspectManifest contains
   expect(arm64.classList.contains('bg-purple-500'));
   expect(x86_64.classList.contains('opacity-50')).toBeFalsy();
 });
+
+test('if a manifest is created that has the label "6.8.9-300.fc40.aarch64" in associated digest images, xfs should be selected by default', async () => {
+  // Mock manifest and image data with Fedora label
+  const mockManifestInspect = {
+    engineId: 'podman1',
+    engineName: 'podman',
+    manifests: [
+      {
+        digest: 'sha256:fedoraImage',
+        mediaType: 'mediaType',
+        platform: {
+          architecture: 'aarch64',
+          features: [],
+          os: 'os',
+          variant: 'variant',
+        },
+        size: 100,
+        urls: ['url1', 'url2'],
+      },
+    ],
+    mediaType: 'mediaType',
+    schemaVersion: 1,
+  };
+
+  const mockFedoraImage = {
+    Id: 'fedoraImage',
+    RepoTags: ['fedora:latest'],
+    Labels: {
+      'ostree.linux': '6.8.9-300.fc40.aarch64',
+    },
+    engineId: 'podman1',
+    engineName: 'podman',
+    ParentId: '',
+    Created: 0,
+    VirtualSize: 0,
+    Size: 0,
+    Containers: 0,
+    SharedSize: 0,
+    Digest: 'sha256:fedoraImage',
+  };
+
+  vi.mocked(bootcClient.inspectManifest).mockResolvedValue(mockManifestInspect);
+  vi.mocked(bootcClient.listHistoryInfo).mockResolvedValue(mockHistoryInfo);
+  vi.mocked(bootcClient.listBootcImages).mockResolvedValue([mockFedoraImage]);
+  vi.mocked(bootcClient.buildExists).mockResolvedValue(false);
+  vi.mocked(bootcClient.checkPrereqs).mockResolvedValue(undefined);
+
+  await waitRender();
+
+  const xfsRadio = screen.getByLabelText('xfs-filesystem-select');
+  expect(xfsRadio).toBeDefined();
+  // expect it to be selected
+  expect(xfsRadio.classList.contains('bg-purple-500'));
+});

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -29,6 +29,7 @@ export abstract class BootcApi {
   abstract deleteBuilds(builds: BootcBuildInfo[]): Promise<void>;
   abstract selectOutputFolder(): Promise<string>;
   abstract listBootcImages(): Promise<ImageInfo[]>;
+  abstract listAllImages(): Promise<ImageInfo[]>;
   abstract listHistoryInfo(): Promise<BootcBuildInfo[]>;
   abstract openFolder(folder: string): Promise<boolean>;
   abstract generateUniqueBuildID(name: string): Promise<string>;


### PR DESCRIPTION
feature: detect fedora image and update filesystem

### What does this PR do?

* Detects if the base image is based upon fedora
* If it is based on fedora, auto-select the filesystem

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/containers/podman-desktop-extension-bootc/assets/6422176/4f82f815-85e9-4b51-91c0-bea27700dbd1



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/457

### How to test this PR?

<!-- Please explain steps to reproduce -->

Select a fedora bootc image or manifest, it will auto-select XFS.

If you select a non-fedora bootc image, it will be default.

Tests also cover new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
