### PR TITLE
chore(tests): wait for a podman provider to be loaded

### DIFF
--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -21,6 +21,7 @@ import { afterAll, beforeAll, test, describe, beforeEach } from 'vitest';
 import {
   ImageDetailsPage,
   NavigationBar,
+  DashboardPage,
   PodmanDesktopRunner,
   WelcomePage,
   deleteImage,
@@ -60,6 +61,10 @@ beforeAll(async () => {
 
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);
+  const dashboardPage = new DashboardPage(page);
+  const podmanEngineStatus = dashboardPage.getPodmanStatusLocator();
+  await playExpect(podmanEngineStatus).toBeVisible({ timeout: 10000 });
+  await playExpect(podmanEngineStatus.getByLabel('Connection Status Label')).toHaveText('RUNNING');
   navBar = new NavigationBar(page);
 });
 


### PR DESCRIPTION
### What does this PR do?
Add a check for a Podman Provider to be available at the beforeAll hook for e2e tests.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#520 
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
