### PR TITLE
chore(test): refactor to use exposed method

### DIFF
--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -24,6 +24,7 @@ import {
   WelcomePage,
   deleteImage,
   removeFolderIfExists,
+  waitForPodmanMachineStartup,
 } from '@podman-desktop/tests-playwright';
 import { expect as playExpect } from '@playwright/test';
 import { RunnerTestContext } from '@podman-desktop/tests-playwright';
@@ -60,10 +61,7 @@ beforeAll(async () => {
   const welcomePage = new WelcomePage(page);
   await welcomePage.handleWelcomePage(true);
   navBar = new NavigationBar(page);
-  const dashboardPage = await navBar.openDashboard();
-  await playExpect(dashboardPage.heading).toBeVisible();
-  await playExpect(dashboardPage.podmanStatusLabel).toBeVisible({ timeout: 10000 });
-  await playExpect(dashboardPage.podmanStatusLabel).toHaveText('RUNNING', { timeout: 10000 });
+  await waitForPodmanMachineStartup(page);
 });
 
 afterAll(async () => {
@@ -124,7 +122,7 @@ describe('BootC Extension', async () => {
         await playExpect.poll(async () => await imagesPage.waitForImageExists(imageName)).toBeTruthy();
       }, 150000);
 
-      test.skipIf(isLinux).each(['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO'])(
+      test.each(['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO'])(
         `Building bootable image type: %s`,
         async type => {
           const imagesPage = await navBar.openImages();

--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -122,7 +122,7 @@ describe('BootC Extension', async () => {
         await playExpect.poll(async () => await imagesPage.waitForImageExists(imageName)).toBeTruthy();
       }, 150000);
 
-      test.each(['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO'])(
+      test.skipIf(isLinux).each(['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO'])(
         `Building bootable image type: %s`,
         async type => {
           const imagesPage = await navBar.openImages();


### PR DESCRIPTION
### What does this PR do?
Refactors bootc e2e tests to call exposed method from test framework

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-extension-bootc/issues/526
