### PR TITLE
chore: use ellipsis in columns

### DIFF
--- a/packages/frontend/src/lib/BootcFolderColumn.svelte
+++ b/packages/frontend/src/lib/BootcFolderColumn.svelte
@@ -1,16 +1,11 @@
 <script lang="ts">
-import { bootcClient } from '../api/client';
 import Link from './Link.svelte';
 import type { BootcBuildInfo } from '/@shared/src/models/bootc';
 
 export let object: BootcBuildInfo;
-
-function openFolder(folder: string) {
-  bootcClient.openFolder(folder);
-}
 </script>
 
-<div class="text-sm">
+<div class="text-sm text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis">
   <Link folder="{object.folder}">
     {object.folder}
   </Link>

--- a/packages/frontend/src/lib/BootcImageColumn.svelte
+++ b/packages/frontend/src/lib/BootcImageColumn.svelte
@@ -4,6 +4,6 @@ import type { BootcBuildInfo } from '/@shared/src/models/bootc';
 export let object: BootcBuildInfo;
 </script>
 
-<div class="text-sm text-[var(--pd-table-body-text-highlight)]">
+<div class="text-sm text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis">
   {object.image}:{object.tag}
 </div>


### PR DESCRIPTION
### What does this PR do?

We did this in Podman Desktop but should do it in bootc - text columns that can be too wide should use ellipsis.

The new bootc Link component (on PD Link component) supports opening folders directly, so we can remove the unused import and function. Added color variable so that ellipsis is grey instead of white.

### Screenshot / video of UI

Before:

<img width="934" alt="Screenshot 2024-06-17 at 4 42 41 PM" src="https://github.com/containers/podman-desktop-extension-bootc/assets/19958075/52bfc23d-71af-4f66-b915-f6f5bdec2078">

After:

<img width="808" alt="Screenshot 2024-06-17 at 4 45 44 PM" src="https://github.com/containers/podman-desktop-extension-bootc/assets/19958075/c4b52d16-3217-4005-99ad-85f1847d79e7">

### What issues does this PR fix or reference?

Fixes #549.

### How to test this PR?

Do a build, make the window narrow.