### PR TITLE
chore: update to latest bootc image builder

### DIFF
--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -18,5 +18,5 @@
 
 // Image related
 export const bootcImageBuilder = 'bootc-image-builder';
-export const bootcImageBuilderCentos = 'quay.io/centos-bootc/bootc-image-builder:latest-1714633180';
+export const bootcImageBuilderCentos = 'quay.io/centos-bootc/bootc-image-builder:latest-1716188954';
 export const bootcImageBuilderRHEL = 'registry.redhat.io/rhel9/bootc-image-builder:9.4';


### PR DESCRIPTION
### What does this PR do?

Updates bootc image builder to latest-1716188954.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Build a few images of different types.