### PR TITLE
fix: build type validation

### DIFF
--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -318,10 +318,11 @@ async function updateBuildType(type: BuildType, selected: boolean) {
   } else {
     buildType = buildType.filter(t => t !== type);
   }
+  validate();
 }
 
 // validate every time a selection changes in the form or available architectures
-$: if (selectedImage || buildFolder || buildType || buildArch || overwrite) {
+$: if (selectedImage || buildFolder || buildArch || overwrite) {
   validate();
 }
 


### PR DESCRIPTION
### What does this PR do?

I wasn't seeing this while testing #576, but it must have been there in some form.

The fix is simple: validation isn't being triggered when the contents of the buildType array change, so just trigger it directly instead of relying on svelte reactivity.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #584.

### How to test this PR?

Enable/disable various build types.