### PR TITLE
chore: light mode, mostly for build page

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0" />
     <title>BootC Extension</title>
   </head>
-  <body class="overflow-auto text-white">
+  <body class="overflow-auto text-[var(--pd-default-text)]">
     <div id="app"></div>
     <script type="module" src="./src/main.ts"></script>
   </body>

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -24,7 +24,7 @@
     "@fortawesome/free-brands-svg-icons": "^6.5.2",
     "@fortawesome/free-regular-svg-icons": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
-    "@podman-desktop/ui-svelte": "1.12.0-202407021227-4f9d4c6",
+    "@podman-desktop/ui-svelte": "1.12.0-202407081130-ca0bb6b",
     "@sveltejs/vite-plugin-svelte": "3.1.1",
     "@tailwindcss/typography": "^0.5.13",
     "@testing-library/dom": "^10.3.1",

--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -193,7 +193,7 @@ test('Check that prereq validation works', async () => {
   const raw = screen.getByLabelText('raw-checkbox');
   raw.click();
 
-  const validation = screen.getByLabelText('validation');
+  const validation = screen.getByRole('alert');
   expect(validation).toBeDefined();
   expect(validation.textContent).toEqual(prereq);
 });
@@ -219,7 +219,7 @@ test('Check that overwriting an existing build works', async () => {
   const overwrite2 = screen.getByLabelText('overwrite-checkbox');
   expect(overwrite2).toBeDefined();
 
-  const validation = screen.getByLabelText('validation');
+  const validation = screen.getByRole('alert');
   expect(validation).toBeDefined();
   expect(validation.textContent).toEqual('Confirm overwriting existing build');
 
@@ -227,7 +227,7 @@ test('Check that overwriting an existing build works', async () => {
   overwrite2.click();
   await new Promise(resolve => setTimeout(resolve, 100));
 
-  const validation2 = screen.queryByLabelText('validation');
+  const validation2 = screen.queryByRole('alert');
   expect(validation2).toBeNull();
 });
 
@@ -316,7 +316,7 @@ test('Test that arm64 is disabled in form if inspectImage returns no arm64', asy
   const x86_64 = screen.getByLabelText('amd64-select');
   expect(x86_64).toBeDefined();
   // Expect it to be "selected"
-  expect(x86_64.classList.contains('bg-purple-500'));
+  expect(x86_64.classList.contains('bg-[var(--pd-content-card-hover-inset-bg)]'));
 });
 
 test('In the rare case that Architecture from inspectImage is blank, do not select either', async () => {
@@ -412,7 +412,7 @@ test('If inspectImage fails, do not select any architecture / make them availabl
   expect(x86_64.classList.contains('opacity-50'));
 
   // Expect Architecture must be selected to be shown
-  const validation = screen.getByLabelText('validation');
+  const validation = screen.getByRole('alert');
   expect(validation).toBeDefined();
   expect(validation.textContent).toEqual('Architecture must be selected');
 });

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -14,7 +14,7 @@ import { onMount } from 'svelte';
 import type { ImageInfo, ManifestInspectInfo } from '@podman-desktop/api';
 import { router } from 'tinro';
 import DiskImageIcon from './lib/DiskImageIcon.svelte';
-import { Button, Input, EmptyScreen, FormPage, Checkbox, Link } from '@podman-desktop/ui-svelte';
+import { Button, Input, EmptyScreen, FormPage, Checkbox, Link, ErrorMessage } from '@podman-desktop/ui-svelte';
 
 export let imageName: string | undefined = undefined;
 export let imageTag: string | undefined = undefined;
@@ -410,7 +410,8 @@ export function goToHomePage(): void {
         </Button>
       </EmptyScreen>
     {:else}
-      <div class="bg-charcoal-900 pt-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg">
+      <div
+        class="bg-[var(--pd-content-card-bg)] pt-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg text-[var(--pd-content-card-header-text)]">
         <div class="{buildInProgress ? 'opacity-40 pointer-events-none' : ''}">
           <div class="pb-4">
             <label for="modalImageTag" class="block mb-2 text-md font-semibold">Bootable container image</label>
@@ -436,15 +437,21 @@ export function goToHomePage(): void {
               </select>
               <!-- Position icon absolutely within the relative container -->
               {#if bootcAvailableImages.length === 0}
-                <Fa class="absolute left-0 top-0 ml-2 mt-3 text-amber-500" size="1x" icon="{faTriangleExclamation}" />
+                <Fa
+                  class="absolute left-0 top-0 ml-2 mt-3 text-[var(--pd-state-warning)]"
+                  size="1x"
+                  icon="{faTriangleExclamation}" />
               {:else if selectedImage}
-                <Fa class="absolute left-0 top-0 ml-2 mt-3 text-green-300" size="1x" icon="{faCube}" />
+                <Fa class="absolute left-0 top-0 ml-2 mt-3 text-[var(--pd-state-success)]" size="1x" icon="{faCube}" />
               {:else}
-                <Fa class="absolute left-0 top-0 ml-2 mt-3 text-gray-500" size="1x" icon="{faQuestionCircle}" />
+                <Fa
+                  class="absolute left-0 top-0 ml-2 mt-3 text-[var(--pd-state-warning)]"
+                  size="1x"
+                  icon="{faQuestionCircle}" />
               {/if}
             </div>
             {#if bootcAvailableImages.length === 0}
-              <p class="text-amber-500 text-sm pt-1">
+              <p class="text-[var(--pd-state-warning)] text-sm pt-1">
                 No bootable container compatible images found. Learn to create one on our <a
                   class="text-purple-400 hover:bg-white hover:bg-opacity-10 transition-all rounded-[4px] p-0.5 no-underline cursor-pointer"
                   href="https://github.com/containers/podman-desktop-extension-bootc">README</a
@@ -515,9 +522,10 @@ export function goToHomePage(): void {
                     class="sr-only peer"
                     aria-label="default-filesystem-select" />
                   <div
-                    class="w-4 h-4 rounded-full border-2 border-gray-400 mr-2 peer-checked:border-purple-500 peer-checked:bg-purple-500">
+                    class="w-4 h-4 rounded-full border-2 border-[var(--pd-input-checkbox-unchecked)] mr-2 peer-checked:border-[var(--pd-input-checkbox-checked)] peer-checked:bg-[var(--pd-input-checkbox-checked)]">
                   </div>
-                  <span class="text-sm {fedoraDetected ? 'text-gray-300' : 'text-white'}">Default</span>
+                  <span class="text-sm {fedoraDetected ? 'text-[var(--pd-input-field-disabled-text)]' : ''}"
+                    >Default</span>
                 </label>
                 <label for="xfsFs" class="ml-1 flex items-center cursor-pointer" aria-label="xfs-radio">
                   <input
@@ -529,9 +537,9 @@ export function goToHomePage(): void {
                     class="sr-only peer"
                     aria-label="xfs-filesystem-select" />
                   <div
-                    class="w-4 h-4 rounded-full border-2 border-gray-400 mr-2 peer-checked:border-purple-500 peer-checked:bg-purple-500">
+                    class="w-4 h-4 rounded-full border-2 border-[var(--pd-input-checkbox-unchecked)] mr-2 peer-checked:border-[var(--pd-input-checkbox-checked)] peer-checked:bg-[var(--pd-input-checkbox-checked)]">
                   </div>
-                  <span class="text-sm text-white">XFS</span>
+                  <span class="text-sm">XFS</span>
                 </label>
                 <label for="ext4Fs" class="ml-1 flex items-center cursor-pointer" aria-label="ext4-radio">
                   <input
@@ -543,21 +551,19 @@ export function goToHomePage(): void {
                     class="sr-only peer"
                     aria-label="ext4-filesystem-select" />
                   <div
-                    class="w-4 h-4 rounded-full border-2 border-gray-400 mr-2 peer-checked:border-purple-500 peer-checked:bg-purple-500">
+                    class="w-4 h-4 rounded-full border-2 border-[var(--pd-input-checkbox-unchecked)] mr-2 peer-checked:border-[var(--pd-input-checkbox-checked)] peer-checked:bg-[var(--pd-input-checkbox-checked)]">
                   </div>
-                  <span class="text-sm text-white">EXT4</span>
+                  <span class="text-sm">EXT4</span>
                 </label>
               </div>
-              {#if fedoraDetected}
-                <p class="text-gray-300 text-xs">
+              <p class="text-xs text-[var(--pd-content-text)]">
+                {#if fedoraDetected}
                   Fedora detected. By default Fedora requires a specific filesystem to be selected. XFS is recommended.
-                </p>
-              {:else}
-                <p class="text-gray-300 text-xs">
+                {:else}
                   The default filesystem is automatically detected based on the base container image. However, some
                   images such as Fedora may require a specific filesystem to be selected.
-                </p>
-              {/if}
+                {/if}
+              </p>
             </div>
             <div class="mb-2">
               <span class="text-md font-semibold mb-2 block">Platform</span>
@@ -574,11 +580,11 @@ export function goToHomePage(): void {
                     disabled="{!availableArchitectures.includes('arm64')}" />
                   <label
                     for="arm64"
-                    class="h-full flex items-center p-5 cursor-pointer rounded-lg bg-zinc-700 border border-transparent focus:outline-none peer-checked:ring-2 peer-checked:ring-violet-500 peer-checked:border-transparent {availableArchitectures.includes(
+                    class="h-full flex items-center p-5 cursor-pointer rounded-md bg-[var(--pd-content-card-inset-bg)] focus:outline-none border-[var(--pd-content-card-border-selected)] peer-checked:bg-[var(--pd-content-card-hover-inset-bg)] {availableArchitectures.includes(
                       'arm64',
                     )
-                      ? 'cursor-pointer hover:border-violet-500'
-                      : 'ring-0 opacity-50'}"
+                      ? 'border-2 cursor-pointer'
+                      : 'border-0 opacity-50'}"
                     aria-label="arm64-button">
                     <i class="fab fa-linux fa-2x"></i>
                     <br />
@@ -597,11 +603,11 @@ export function goToHomePage(): void {
                     disabled="{!availableArchitectures.includes('amd64')}" />
                   <label
                     for="amd64"
-                    class="h-full flex items-center p-5 cursor-pointer rounded-lg bg-zinc-700 border border-transparent focus:outline-none peer-checked:ring-2 peer-checked:ring-violet-500 peer-checked:border-transparent {availableArchitectures.includes(
+                    class="h-full flex items-center p-5 cursor-pointer rounded-md bg-[var(--pd-content-card-inset-bg)] focus:outline-none border-[var(--pd-content-card-border-selected)] peer-checked:bg-[var(--pd-content-card-hover-inset-bg)] {availableArchitectures.includes(
                       'amd64',
                     )
-                      ? 'cursor-pointer hover:border-violet-500'
-                      : 'ring-0 opacity-50'}"
+                      ? 'border-2 cursor-pointer'
+                      : 'border-0 opacity-50'}"
                     aria-label="amd64-button">
                     <i class="fab fa-linux fa-2x"></i>
                     <br />
@@ -609,7 +615,7 @@ export function goToHomePage(): void {
                   </label>
                 </li>
               </ul>
-              <p class="text-gray-300 text-xs pt-2">
+              <p class="text-xs text-[var(--pd-content-text)] pt-2">
                 Disk image architecture must match the architecture of the original image. For example, you must have an
                 ARM container image to build an ARM disk image. You can only select the architecture that is detectable
                 within the image or manifest.
@@ -630,7 +636,7 @@ export function goToHomePage(): void {
                   <span class="text-sm font-semibold mb-2 block">Upload image to AWS</span>
                 </div>
 
-                <label for="amiName" class="block mb-2 text-sm font-bold text-gray-400">AMI Name</label>
+                <label for="amiName" class="block mb-2 text-sm font-bold">AMI Name</label>
                 <Input
                   bind:value="{awsAmiName}"
                   name="amiName"
@@ -638,7 +644,7 @@ export function goToHomePage(): void {
                   placeholder="AMI Name to be used"
                   class="w-full" />
 
-                <label for="awsBucket" class="block mb-2 text-sm font-bold text-gray-400">S3 Bucket</label>
+                <label for="awsBucket" class="block mb-2 text-sm font-bold">S3 Bucket</label>
                 <Input
                   bind:value="{awsBucket}"
                   name="awsBucket"
@@ -646,7 +652,7 @@ export function goToHomePage(): void {
                   placeholder="AWS S3 bucket"
                   class="w-full" />
 
-                <label for="awsRegion" class="block mb-2 text-sm font-bold text-gray-400">S3 Region</label>
+                <label for="awsRegion" class="block mb-2 text-sm font-bold">S3 Region</label>
                 <Input
                   bind:value="{awsRegion}"
                   name="awsRegion"
@@ -654,7 +660,7 @@ export function goToHomePage(): void {
                   placeholder="AWS S3 region"
                   class="w-full" />
 
-                <p class="text-gray-300 text-xs pt-2">
+                <p class="text-xs text-[var(--pd-content-text)] pt-2">
                   This will upload the image to a specific AWS S3 bucket. Credentials stored at ~/.aws/credentials will
                   be used for uploading. You must have <Link
                     externalRef="https://docs.aws.amazon.com/vm-import/latest/userguide/required-permissions.html"
@@ -669,7 +675,7 @@ export function goToHomePage(): void {
             Overwrite existing build</Checkbox>
         {/if}
         {#if errorFormValidation}
-          <div aria-label="validation" class="bg-red-800 p-3 rounded-md text-white text-sm">{errorFormValidation}</div>
+          <ErrorMessage aria-label="validation" error="{errorFormValidation}" />
         {/if}
         {#if buildInProgress}
           <Button class="w-full" disabled="{true}">Creating build task</Button>

--- a/packages/frontend/src/lib/BootcStatusIcon.svelte
+++ b/packages/frontend/src/lib/BootcStatusIcon.svelte
@@ -27,7 +27,8 @@ $: solid =
     class:p-0.5="{!solid}"
     class:p-1="{solid}"
     class:border-gray-700="{!solid}"
-    class:text-gray-700="{!solid}"
+    class:text-[var(--pd-status-not-running)]="{!solid}"
+    class:text-[var(--pd-status-contrast)]="{solid}"
     role="status"
     title="{status}">
     {#if status === 'running' || status === 'creating' || status === 'deleting'}

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,10 +392,10 @@
   resolved "https://registry.yarnpkg.com/@podman-desktop/tests-playwright/-/tests-playwright-1.11.1.tgz#0d9944367853ba81df828c633c6dae4a7a954409"
   integrity sha512-qwVOagtPopld3/LgZkGhl+HgexpCPrJ/uc1r/yR0bJk8Wiz2Ox+xGfljihav/8lAgHue0z6wI9hxgbVEmxaQnQ==
 
-"@podman-desktop/ui-svelte@1.12.0-202407021227-4f9d4c6":
-  version "1.12.0-202407021227-4f9d4c6"
-  resolved "https://registry.yarnpkg.com/@podman-desktop/ui-svelte/-/ui-svelte-1.12.0-202407021227-4f9d4c6.tgz#32320c66ecceef21d03ac333b736affd61870179"
-  integrity sha512-gHbrgopcOj6mET0HqGHjtLBnnFnUGRxtzJniVTogJGvI4VfprDuhXGbyjZMuZStAhg2zD6OegPLrxpAcBJd3Fg==
+"@podman-desktop/ui-svelte@1.12.0-202407081130-ca0bb6b":
+  version "1.12.0-202407081130-ca0bb6b"
+  resolved "https://registry.yarnpkg.com/@podman-desktop/ui-svelte/-/ui-svelte-1.12.0-202407081130-ca0bb6b.tgz#3b1e28f93216ad8a6c50312114927c0820950d9c"
+  integrity sha512-ZeCgeTLDgBmIj84sIyBJbxynjYgP0vbHktQ1D2HYE1Z7Y3XNu5YEP6Wp1m1S++kv2QQ++WPkwKwSCI8Xabho0A==
   dependencies:
     "@fortawesome/fontawesome-free" "^6.5.2"
     "@fortawesome/free-brands-svg-icons" "^6.5.2"
@@ -3790,16 +3790,7 @@ std-env@^3.5.0:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.7.0.tgz#c9f7386ced6ecf13360b6c6c55b8aaa4ef7481d2"
   integrity sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3845,14 +3836,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4437,16 +4421,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
### What does this PR do?

Move up to latest ui-svelte in order to do the following. Requires a recent Podman Desktop build in order for variables to be defined at runtime.

In the Build form, pick up status colors, switch to use ErrorMessage component, and pick up other light mode color variables. Uses the same styling as PD for the tiles, and radio buttons use the checkbox color variables (since PD has no vars for radio inputs).

Use status colors in bootc status icon for now - we should probably reuse StatusIcon now, but that's separate work.

After doing this, we can even set the default text color in the index.

### Screenshot / video of UI

<img width="976" alt="Screenshot 2024-07-08 at 12 16 46 PM" src="https://github.com/containers/podman-desktop-extension-bootc/assets/19958075/3a05ea88-f35e-4643-ad47-6b24882af659">

### What issues does this PR fix or reference?

Not marking this as 'fixes' since we still need a select component, but this is most of #540.

### How to test this PR?

Check the homepage and build page in light and dark modes.