### PR TITLE
feat: be able to use build config

### DIFF
--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -97,6 +97,24 @@ export class BootcApiImpl implements BootcApi {
     return '';
   }
 
+  // Build config file will only ever be config.yaml or config.json as per bootc-iamge-builder requirements / constraints
+  async selectBuildConfigFile(): Promise<string> {
+    const path = await podmanDesktopApi.window.showOpenDialog({
+      title: 'Select build config file',
+      selectors: ['openFile'],
+      filters: [
+        {
+          name: '*',
+          extensions: ['toml', 'json'],
+        },
+      ],
+    });
+    if (path && path.length > 0) {
+      return path[0].fsPath;
+    }
+    return '';
+  }
+
   async listAllImages(): Promise<ImageInfo[]> {
     let images: ImageInfo[] = [];
     try {

--- a/packages/backend/src/build-disk-image.spec.ts
+++ b/packages/backend/src/build-disk-image.spec.ts
@@ -373,3 +373,51 @@ test('test that if aws options are not provided, they are NOT included in the co
   expect(options.Cmd).not.toContain('--aws-region');
   expect(options.Cmd).not.toContain('--aws-ami-name');
 });
+
+test('test if build config toml passed in, it will work', async () => {
+  const name = 'test123-bootc-image-builder';
+  const build = {
+    image: 'test-image',
+    tag: 'latest',
+    type: ['raw'],
+    arch: 'amd64',
+    folder: '/tmp/foo/bar/qemutest4',
+    buildConfigFilePath: '/tmp/foo/bar/baz/config.toml',
+  } as BootcBuildInfo;
+
+  const options = createBuilderImageOptions(name, build);
+
+  expect(options).toBeDefined();
+  expect(options.HostConfig).toBeDefined();
+  expect(options.HostConfig?.Binds).toBeDefined();
+  if (options.HostConfig?.Binds) {
+    expect(options.HostConfig.Binds.length).toEqual(3);
+    expect(options.HostConfig.Binds[0]).toEqual(build.folder + ':/output/');
+    expect(options.HostConfig.Binds[1]).toEqual('/var/lib/containers/storage:/var/lib/containers/storage');
+    expect(options.HostConfig.Binds[2]).toEqual(build.buildConfigFilePath + ':/config.toml:ro');
+  }
+});
+
+test('test build config json passed in', async () => {
+  const name = 'test123-bootc-image-builder';
+  const build = {
+    image: 'test-image',
+    tag: 'latest',
+    type: ['raw'],
+    arch: 'amd64',
+    folder: '/tmp/foo/bar/qemutest4',
+    buildConfigFilePath: '/tmp/foo/bar/baz/config.json',
+  } as BootcBuildInfo;
+
+  const options = createBuilderImageOptions(name, build);
+
+  expect(options).toBeDefined();
+  expect(options.HostConfig).toBeDefined();
+  expect(options.HostConfig?.Binds).toBeDefined();
+  if (options.HostConfig?.Binds) {
+    expect(options.HostConfig.Binds.length).toEqual(3);
+    expect(options.HostConfig.Binds[0]).toEqual(build.folder + ':/output/');
+    expect(options.HostConfig.Binds[1]).toEqual('/var/lib/containers/storage:/var/lib/containers/storage');
+    expect(options.HostConfig.Binds[2]).toEqual(build.buildConfigFilePath + ':/config.json:ro');
+  }
+});

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -382,6 +382,19 @@ export function createBuilderImageOptions(
     }
   }
 
+  // If the buildConfigFilePath is defined, we will add the mounted volume of the buildConfigFilePath to the container.
+  // also check if .toml or .json as that is what is supported by bootc-image-builder
+  if (build.buildConfigFilePath) {
+    // The config file name can be anything, but we must only ever mount it as config.toml or config.json
+    const configFileName = path.basename(build.buildConfigFilePath);
+    const ext = path.extname(configFileName);
+
+    // Add the mount to the configuration file.
+    if (options.HostConfig?.Binds) {
+      options.HostConfig.Binds.push(build.buildConfigFilePath + `:/config${ext}:ro`);
+    }
+  }
+
   return options;
 }
 

--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -704,6 +704,10 @@ test('collapse and uncollapse of advanced options', async () => {
   const amiRegion = screen.queryByRole('label', { name: 'S3 Region' });
   expect(amiRegion).toBeNull();
 
+  // Expect Build Config to be hidden
+  const buildConfig = screen.queryByRole('label', { name: 'Build config' });
+  expect(buildConfig).toBeNull();
+
   // Click on the Advanced Options span
   advancedOptions.click();
 
@@ -716,4 +720,7 @@ test('collapse and uncollapse of advanced options', async () => {
   // expect the label "S3 Region" to be shown
   const amiRegion2 = screen.queryByRole('label', { name: 'S3 Region' });
   expect(amiRegion2).toBeDefined();
+  // expect build config to be shown
+  const buildConfig2 = screen.queryByRole('label', { name: 'Build config' });
+  expect(buildConfig2).toBeDefined();
 });

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -420,7 +420,7 @@ export function goToHomePage(): void {
         class="bg-[var(--pd-content-card-bg)] pt-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg text-[var(--pd-content-card-header-text)]">
         <div class="{buildInProgress ? 'opacity-40 pointer-events-none' : ''}">
           <div class="pb-4">
-            <label for="modalImageTag" class="block mb-2 text-md font-semibold">Bootable container image</label>
+            <label for="modalImageTag" class="block mb-2 text-base font-semibold">Bootable container image</label>
             <div class="relative">
               <!-- Container with relative positioning -->
               <select
@@ -466,7 +466,7 @@ export function goToHomePage(): void {
             {/if}
           </div>
           <div>
-            <label for="path" class="block mb-2 text-md font-semibold">Output folder</label>
+            <label for="path" class="block mb-2 text-base font-semibold">Output folder</label>
             <div class="flex flex-row space-x-3">
               <Input
                 name="path"
@@ -480,7 +480,7 @@ export function goToHomePage(): void {
           </div>
           <div class="pt-3 space-y-3 h-fit">
             <div class="mb-2">
-              <span class="text-md font-semibold mb-2 block">Disk image type</span>
+              <span class="text-base font-semibold mb-2 block">Disk image type</span>
               <div class="flex flex-col text-sm ml-1 space-y-2">
                 <Checkbox
                   checked="{buildType.includes('raw')}"
@@ -515,7 +515,7 @@ export function goToHomePage(): void {
               </div>
             </div>
             <div>
-              <span class="text-md font-semibold mb-2 block">Filesystem</span>
+              <span class="text-base font-semibold mb-2 block">Filesystem</span>
               <div class="flex items-center mb-3 space-x-3">
                 <label for="defaultFs" class="ml-1 flex items-center cursor-pointer" aria-label="default-radio">
                   <input
@@ -572,7 +572,7 @@ export function goToHomePage(): void {
               </p>
             </div>
             <div class="mb-2">
-              <span class="text-md font-semibold mb-2 block">Platform</span>
+              <span class="text-base font-semibold mb-2 block">Platform</span>
               <ul class="grid grid-cols-2 gap-x-2 max-w-md">
                 <li>
                   <input
@@ -632,7 +632,7 @@ export function goToHomePage(): void {
               <!-- svelte-ignore a11y-click-events-have-key-events -->
               <!-- svelte-ignore a11y-no-static-element-interactions -->
               <span
-                class="text-md font-semibold mb-2 block cursor-pointer"
+                class="text-base font-semibold mb-2 block cursor-pointer"
                 aria-label="advanced-options"
                 on:click="{toggleAdvanced}"
                 ><Fa icon="{showAdvanced ? faCaretDown : faCaretRight}" class="inline-block mr-1" /> Advanced Options
@@ -640,7 +640,7 @@ export function goToHomePage(): void {
               {#if showAdvanced}
                 <!-- Build config -->
                 <div class="mb-2">
-                  <label for="buildconfig" class="block mb-2 text-md font-semibold">Build config</label>
+                  <label for="buildconfig" class="block mb-2 text-base font-semibold">Build config</label>
                   <div class="flex flex-row space-x-3">
                     <Input
                       name="buildconfig"
@@ -663,10 +663,10 @@ export function goToHomePage(): void {
 
                 <!-- AWS -->
                 <div>
-                  <span class="text-md font-semibold mb-2 block">Upload image to AWS</span>
+                  <span class="text-base font-semibold block">Upload image to AWS</span>
                 </div>
 
-                <label for="amiName" class="block mb-2 text-sm font-bold">AMI Name</label>
+                <label for="amiName" class="block mt-2 text-sm font-bold">AMI Name</label>
                 <Input
                   bind:value="{awsAmiName}"
                   name="amiName"
@@ -674,7 +674,7 @@ export function goToHomePage(): void {
                   placeholder="AMI Name to be used"
                   class="w-full" />
 
-                <label for="awsBucket" class="block mb-2 text-sm font-bold">S3 Bucket</label>
+                <label for="awsBucket" class="block mt-2 text-sm font-bold">S3 Bucket</label>
                 <Input
                   bind:value="{awsBucket}"
                   name="awsBucket"
@@ -682,7 +682,7 @@ export function goToHomePage(): void {
                   placeholder="AWS S3 bucket"
                   class="w-full" />
 
-                <label for="awsRegion" class="block mb-2 text-sm font-bold">S3 Region</label>
+                <label for="awsRegion" class="block mt-2 text-sm font-bold">S3 Region</label>
                 <Input
                   bind:value="{awsRegion}"
                   name="awsRegion"

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -33,6 +33,7 @@ let availableArchitectures: string[] = [];
 
 // Build options
 let buildFolder: string;
+let buildConfigFile: string;
 let buildType: BuildType[] = [];
 let buildArch: string | undefined;
 let buildFilesystem: string = ''; // Default filesystem auto-selected / empty
@@ -184,6 +185,7 @@ async function buildBootcImage() {
     tag: selectedImage.split(':')[1],
     engineId: image?.engineId ?? '',
     folder: buildFolder,
+    buildConfigFilePath: buildConfigFile,
     type: buildType,
     arch: buildArch,
     filesystem: buildFilesystem,
@@ -235,6 +237,10 @@ async function buildBootcImage() {
 
 async function getPath() {
   buildFolder = await bootcClient.selectOutputFolder();
+}
+
+async function getBuildConfigFile() {
+  buildConfigFile = await bootcClient.selectBuildConfigFile();
 }
 
 function cleanup() {
@@ -632,8 +638,32 @@ export function goToHomePage(): void {
                 ><Fa icon="{showAdvanced ? faCaretDown : faCaretRight}" class="inline-block mr-1" /> Advanced Options
               </span>
               {#if showAdvanced}
+                <!-- Build config -->
+                <div class="mb-2">
+                  <label for="buildconfig" class="block mb-2 text-md font-semibold">Build config</label>
+                  <div class="flex flex-row space-x-3">
+                    <Input
+                      name="buildconfig"
+                      id="buildconfig"
+                      bind:value="{buildConfigFile}"
+                      placeholder="Build configuration file (config.toml or config.json)"
+                      class="w-full"
+                      aria-label="buildconfig-select" />
+                    <Button on:click="{() => getBuildConfigFile()}">Browse...</Button>
+                  </div>
+                  <p class="text-xs text-[var(--pd-content-text)] pt-2">
+                    The build configuration file is a TOML or JSON file that contains the build options for the disk
+                    image. Customizations include user, password, SSH keys and kickstart files. More information can be
+                    found in the <Link
+                      externalRef="https://github.com/osbuild/bootc-image-builder?tab=readme-ov-file#-build-config"
+                      >bootc-image-builder documentation</Link
+                    >.
+                  </p>
+                </div>
+
+                <!-- AWS -->
                 <div>
-                  <span class="text-sm font-semibold mb-2 block">Upload image to AWS</span>
+                  <span class="text-md font-semibold mb-2 block">Upload image to AWS</span>
                 </div>
 
                 <label for="amiName" class="block mb-2 text-sm font-bold">AMI Name</label>

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -28,6 +28,7 @@ export abstract class BootcApi {
   abstract inspectManifest(image: ImageInfo): Promise<ManifestInspectInfo>;
   abstract deleteBuilds(builds: BootcBuildInfo[]): Promise<void>;
   abstract selectOutputFolder(): Promise<string>;
+  abstract selectBuildConfigFile(): Promise<string>;
   abstract listBootcImages(): Promise<ImageInfo[]>;
   abstract listAllImages(): Promise<ImageInfo[]>;
   abstract listHistoryInfo(): Promise<BootcBuildInfo[]>;

--- a/packages/shared/src/models/bootc.ts
+++ b/packages/shared/src/models/bootc.ts
@@ -25,6 +25,7 @@ export interface BootcBuildInfo {
   engineId: string;
   type: BuildType[];
   folder: string;
+  buildConfigFilePath?: string;
   filesystem?: string;
   arch?: string;
   status?: BootcBuildStatus;


### PR DESCRIPTION
feat: be able to use build config

### What does this PR do?

* Under advanced have build config file option
* Be able to pass in YAML or JSON file
* Misc: Fixes size of font for AWS options

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2024-07-09 at 2 00 25 PM](https://github.com/containers/podman-desktop-extension-bootc/assets/6422176/3c41c29e-78ad-4032-8e2b-d4485fac73db)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/471

### How to test this PR?

1. Use our test bootc image
2. Create a TOML file with the following:

```
[[customizations.user]]
name = "root"
password = "letmein"
```

3. Build image
4. Confirm you can login
5. Test again with a JSON file:
```
{
  "customizations": {
    "user": [
      {
        "name": "root",
        "password": "letmein2"
      }
    ]
  }
}
```

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
