### PR TITLE
chore: font size and consistency

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0" />
     <title>BootC Extension</title>
   </head>
-  <body class="overflow-auto text-[var(--pd-default-text)]">
+  <body class="overflow-auto text-base text-[var(--pd-default-text)]">
     <div id="app"></div>
     <script type="module" src="./src/main.ts"></script>
   </body>

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -24,7 +24,7 @@
     "@fortawesome/free-brands-svg-icons": "^6.5.2",
     "@fortawesome/free-regular-svg-icons": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
-    "@podman-desktop/ui-svelte": "1.12.0-202407081130-ca0bb6b",
+    "@podman-desktop/ui-svelte": "1.12.0-202407121347-48f183b",
     "@sveltejs/vite-plugin-svelte": "3.1.1",
     "@tailwindcss/typography": "^0.5.13",
     "@testing-library/dom": "^10.3.1",

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -420,11 +420,11 @@ export function goToHomePage(): void {
         class="bg-[var(--pd-content-card-bg)] pt-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg text-[var(--pd-content-card-header-text)]">
         <div class="{buildInProgress ? 'opacity-40 pointer-events-none' : ''}">
           <div class="pb-4">
-            <label for="modalImageTag" class="block mb-2 text-base font-semibold">Bootable container image</label>
+            <label for="modalImageTag" class="block mb-2 font-semibold">Bootable container image</label>
             <div class="relative">
               <!-- Container with relative positioning -->
               <select
-                class="text-sm rounded-lg block w-full p-2.5 bg-charcoal-600 pl-8 border-r-8 border-transparent outline-1 outline outline-gray-900 placeholder-gray-700 text-white"
+                class="rounded-lg block w-full p-2.5 bg-charcoal-600 pl-8 border-r-8 border-transparent outline-1 outline outline-gray-900 placeholder-gray-700 text-white"
                 name="imageChoice"
                 aria-label="image-select"
                 bind:value="{selectedImage}">
@@ -457,7 +457,7 @@ export function goToHomePage(): void {
               {/if}
             </div>
             {#if bootcAvailableImages.length === 0}
-              <p class="text-[var(--pd-state-warning)] text-sm pt-1">
+              <p class="text-[var(--pd-state-warning)] pt-1">
                 No bootable container compatible images found. Learn to create one on our <a
                   class="text-purple-400 hover:bg-white hover:bg-opacity-10 transition-all rounded-[4px] p-0.5 no-underline cursor-pointer"
                   href="https://github.com/containers/podman-desktop-extension-bootc">README</a
@@ -466,7 +466,7 @@ export function goToHomePage(): void {
             {/if}
           </div>
           <div>
-            <label for="path" class="block mb-2 text-base font-semibold">Output folder</label>
+            <label for="path" class="block mb-2 font-semibold">Output folder</label>
             <div class="flex flex-row space-x-3">
               <Input
                 name="path"
@@ -480,8 +480,8 @@ export function goToHomePage(): void {
           </div>
           <div class="pt-3 space-y-3 h-fit">
             <div class="mb-2">
-              <span class="text-base font-semibold mb-2 block">Disk image type</span>
-              <div class="flex flex-col text-sm ml-1 space-y-2">
+              <span class="text-md font-semibold mb-2 block">Disk image type</span>
+              <div class="flex flex-col ml-1 space-y-2">
                 <Checkbox
                   checked="{buildType.includes('raw')}"
                   title="raw-checkbox"
@@ -515,7 +515,7 @@ export function goToHomePage(): void {
               </div>
             </div>
             <div>
-              <span class="text-base font-semibold mb-2 block">Filesystem</span>
+              <span class="font-semibold mb-2 block">Filesystem</span>
               <div class="flex items-center mb-3 space-x-3">
                 <label for="defaultFs" class="ml-1 flex items-center cursor-pointer" aria-label="default-radio">
                   <input
@@ -530,8 +530,7 @@ export function goToHomePage(): void {
                   <div
                     class="w-4 h-4 rounded-full border-2 border-[var(--pd-input-checkbox-unchecked)] mr-2 peer-checked:border-[var(--pd-input-checkbox-checked)] peer-checked:bg-[var(--pd-input-checkbox-checked)]">
                   </div>
-                  <span class="text-sm {fedoraDetected ? 'text-[var(--pd-input-field-disabled-text)]' : ''}"
-                    >Default</span>
+                  <span class="{fedoraDetected ? 'text-[var(--pd-input-field-disabled-text)]' : ''}">Default</span>
                 </label>
                 <label for="xfsFs" class="ml-1 flex items-center cursor-pointer" aria-label="xfs-radio">
                   <input
@@ -545,7 +544,7 @@ export function goToHomePage(): void {
                   <div
                     class="w-4 h-4 rounded-full border-2 border-[var(--pd-input-checkbox-unchecked)] mr-2 peer-checked:border-[var(--pd-input-checkbox-checked)] peer-checked:bg-[var(--pd-input-checkbox-checked)]">
                   </div>
-                  <span class="text-sm">XFS</span>
+                  <span>XFS</span>
                 </label>
                 <label for="ext4Fs" class="ml-1 flex items-center cursor-pointer" aria-label="ext4-radio">
                   <input
@@ -559,10 +558,10 @@ export function goToHomePage(): void {
                   <div
                     class="w-4 h-4 rounded-full border-2 border-[var(--pd-input-checkbox-unchecked)] mr-2 peer-checked:border-[var(--pd-input-checkbox-checked)] peer-checked:bg-[var(--pd-input-checkbox-checked)]">
                   </div>
-                  <span class="text-sm">EXT4</span>
+                  <span>EXT4</span>
                 </label>
               </div>
-              <p class="text-xs text-[var(--pd-content-text)]">
+              <p class="text-sm text-[var(--pd-content-text)]">
                 {#if fedoraDetected}
                   Fedora detected. By default Fedora requires a specific filesystem to be selected. XFS is recommended.
                 {:else}
@@ -572,7 +571,7 @@ export function goToHomePage(): void {
               </p>
             </div>
             <div class="mb-2">
-              <span class="text-base font-semibold mb-2 block">Platform</span>
+              <span class="font-semibold mb-2 block">Platform</span>
               <ul class="grid grid-cols-2 gap-x-2 max-w-md">
                 <li>
                   <input
@@ -594,7 +593,7 @@ export function goToHomePage(): void {
                     aria-label="arm64-button">
                     <i class="fab fa-linux fa-2x"></i>
                     <br />
-                    <span class="ml-2 text-sm">ARM® aarch64 systems</span>
+                    <span class="ml-2">ARM® aarch64 systems</span>
                   </label>
                 </li>
                 <li>
@@ -617,11 +616,11 @@ export function goToHomePage(): void {
                     aria-label="amd64-button">
                     <i class="fab fa-linux fa-2x"></i>
                     <br />
-                    <span class="ml-2 text-sm">Intel and AMD x86_64 systems</span>
+                    <span class="ml-2">Intel and AMD x86_64 systems</span>
                   </label>
                 </li>
               </ul>
-              <p class="text-xs text-[var(--pd-content-text)] pt-2">
+              <p class="text-sm text-[var(--pd-content-text)] pt-2">
                 Disk image architecture must match the architecture of the original image. For example, you must have an
                 ARM container image to build an ARM disk image. You can only select the architecture that is detectable
                 within the image or manifest.
@@ -632,15 +631,15 @@ export function goToHomePage(): void {
               <!-- svelte-ignore a11y-click-events-have-key-events -->
               <!-- svelte-ignore a11y-no-static-element-interactions -->
               <span
-                class="text-base font-semibold mb-2 block cursor-pointer"
+                class="font-semibold mb-2 block cursor-pointer"
                 aria-label="advanced-options"
                 on:click="{toggleAdvanced}"
-                ><Fa icon="{showAdvanced ? faCaretDown : faCaretRight}" class="inline-block mr-1" /> Advanced Options
+                ><Fa icon="{showAdvanced ? faCaretDown : faCaretRight}" class="inline-block mr-1" />Advanced Options
               </span>
               {#if showAdvanced}
                 <!-- Build config -->
                 <div class="mb-2">
-                  <label for="buildconfig" class="block mb-2 text-base font-semibold">Build config</label>
+                  <label for="buildconfig" class="block mb-2 font-semibold">Build config</label>
                   <div class="flex flex-row space-x-3">
                     <Input
                       name="buildconfig"
@@ -651,7 +650,7 @@ export function goToHomePage(): void {
                       aria-label="buildconfig-select" />
                     <Button on:click="{() => getBuildConfigFile()}">Browse...</Button>
                   </div>
-                  <p class="text-xs text-[var(--pd-content-text)] pt-2">
+                  <p class="text-sm text-[var(--pd-content-text)] pt-2">
                     The build configuration file is a TOML or JSON file that contains the build options for the disk
                     image. Customizations include user, password, SSH keys and kickstart files. More information can be
                     found in the <Link
@@ -663,7 +662,7 @@ export function goToHomePage(): void {
 
                 <!-- AWS -->
                 <div>
-                  <span class="text-base font-semibold block">Upload image to AWS</span>
+                  <span class="font-semibold block">Upload image to AWS</span>
                 </div>
 
                 <label for="amiName" class="block mt-2 text-sm font-bold">AMI Name</label>
@@ -690,7 +689,7 @@ export function goToHomePage(): void {
                   placeholder="AWS S3 region"
                   class="w-full" />
 
-                <p class="text-xs text-[var(--pd-content-text)] pt-2">
+                <p class="text-sm text-[var(--pd-content-text)] pt-2">
                   This will upload the image to a specific AWS S3 bucket. Credentials stored at ~/.aws/credentials will
                   be used for uploading. You must have <Link
                     externalRef="https://docs.aws.amazon.com/vm-import/latest/userguide/required-permissions.html"
@@ -701,7 +700,7 @@ export function goToHomePage(): void {
           </div>
         </div>
         {#if existingBuild}
-          <Checkbox class="ml-1 text-sm" title="overwrite-checkbox" bind:checked="{overwrite}">
+          <Checkbox class="ml-1" title="overwrite-checkbox" bind:checked="{overwrite}">
             Overwrite existing build</Checkbox>
         {/if}
         {#if errorFormValidation}

--- a/packages/frontend/src/lib/BootcEmptyScreen.svelte
+++ b/packages/frontend/src/lib/BootcEmptyScreen.svelte
@@ -102,7 +102,7 @@ $: {
         title="Pull image">Pull {exampleImage}</Button>
     {/if}
     {#if displayDisclaimer}
-      <p class="text-[var(--pd-status-waiting)] text-xs">
+      <p class="text-[var(--pd-status-waiting)] text-sm">
         The file size of the image is over 1.5GB and may take a while to download.
       </p>
     {/if}

--- a/packages/frontend/src/lib/BootcFolderColumn.svelte
+++ b/packages/frontend/src/lib/BootcFolderColumn.svelte
@@ -5,7 +5,7 @@ import type { BootcBuildInfo } from '/@shared/src/models/bootc';
 export let object: BootcBuildInfo;
 </script>
 
-<div class="text-sm text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis">
+<div class="text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis">
   <Link folder="{object.folder}">
     {object.folder}
   </Link>

--- a/packages/frontend/src/lib/BootcImageColumn.svelte
+++ b/packages/frontend/src/lib/BootcImageColumn.svelte
@@ -4,6 +4,6 @@ import type { BootcBuildInfo } from '/@shared/src/models/bootc';
 export let object: BootcBuildInfo;
 </script>
 
-<div class="text-sm text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis">
+<div class="text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis">
   {object.image}:{object.tag}
 </div>

--- a/packages/frontend/tailwind.config.cjs
+++ b/packages/frontend/tailwind.config.cjs
@@ -27,6 +27,18 @@ module.exports = {
   ],
   darkMode: 'class',
   theme: {
+    fontSize: {
+      'xs': '10px',
+      'sm': '11px',
+      'base': '12px',
+      'lg': '14px',
+      'xl': '16px',
+      '2xl': '18px',
+      '3xl': '20px',
+      '4xl': '24px',
+      '5xl': '30px',
+      '6xl': '36px',
+    },
     extend: {
       boxShadow: {
         "titlebar": 'inset 0px -1px 0px 0 rgb(54 54 61 / 0.6)', // highlight for bottom of titlebar

--- a/yarn.lock
+++ b/yarn.lock
@@ -385,10 +385,10 @@
   resolved "https://registry.yarnpkg.com/@podman-desktop/tests-playwright/-/tests-playwright-1.11.1.tgz#0d9944367853ba81df828c633c6dae4a7a954409"
   integrity sha512-qwVOagtPopld3/LgZkGhl+HgexpCPrJ/uc1r/yR0bJk8Wiz2Ox+xGfljihav/8lAgHue0z6wI9hxgbVEmxaQnQ==
 
-"@podman-desktop/ui-svelte@1.12.0-202407081130-ca0bb6b":
-  version "1.12.0-202407081130-ca0bb6b"
-  resolved "https://registry.yarnpkg.com/@podman-desktop/ui-svelte/-/ui-svelte-1.12.0-202407081130-ca0bb6b.tgz#3b1e28f93216ad8a6c50312114927c0820950d9c"
-  integrity sha512-ZeCgeTLDgBmIj84sIyBJbxynjYgP0vbHktQ1D2HYE1Z7Y3XNu5YEP6Wp1m1S++kv2QQ++WPkwKwSCI8Xabho0A==
+"@podman-desktop/ui-svelte@1.12.0-202407121347-48f183b":
+  version "1.12.0-202407121347-48f183b"
+  resolved "https://registry.yarnpkg.com/@podman-desktop/ui-svelte/-/ui-svelte-1.12.0-202407121347-48f183b.tgz#4c65eb34c5322d651794fc74c1c8ca9c3d36f0d9"
+  integrity sha512-HGHXqWfdEZplGCCmZkNttEW1UK3OZPgSZQluLpDiFyiV4DwrynzVCAp5FpFvXt9VMWsy7nwvi/CdJ+HttHAXsA==
   dependencies:
     "@fortawesome/fontawesome-free" "^6.5.2"
     "@fortawesome/free-brands-svg-icons" "^6.5.2"


### PR DESCRIPTION
### What does this PR do?

Match up with the new font sizes / consistency as Podman Desktop:
- Pick up the latest svelte-ui (changes to input/button font).
- Set the same font sizes as Podman Desktop.
- Set the default font size in index.html.
- Make equivalent size changes in Homepage and Build page - mostly removing text-sm or moving from -xs to -sm.

### Screenshot / video of UI

Before:

<img width="423" alt="Screenshot 2024-07-12 at 12 06 46 PM" src="https://github.com/user-attachments/assets/26291d89-0b54-4674-8f60-398c11536545">

After:

<img width="423" alt="Screenshot 2024-07-12 at 12 00 29 PM" src="https://github.com/user-attachments/assets/66aed1ae-2089-41ea-ac5f-24ed2158336e">

### What issues does this PR fix or reference?

Fixes #625.

### How to test this PR?

Go to homepage and build page.