### PR TITLE
chore(test): wait for list to update in build page

### DIFF
--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -136,7 +136,6 @@ describe('BootC Extension', async () => {
           [page, webview] = await handleWebview();
           const bootcPage = new BootcPage(page, webview);
           const result = await bootcPage.buildDiskImage(`${imageName}:${imageTag}`, pathToStore, type, architecture);
-          console.log(`Result: ${result}`);
           console.log(
             `Building disk image for platform ${os.platform()} and architecture ${architecture} and type ${type} is ${result}`,
           );

--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -136,9 +136,14 @@ describe('BootC Extension', async () => {
           [page, webview] = await handleWebview();
           const bootcPage = new BootcPage(page, webview);
           const result = await bootcPage.buildDiskImage(`${imageName}:${imageTag}`, pathToStore, type, architecture);
+          console.log(
+            `Building disk image for platform ${os.platform()} and architecture ${architecture} and type ${type} is ${result}`,
+          );
           if (isWindows && architecture === ArchitectureType.ARM64) {
+            console.log('Expected to fail on Windows for ARM64');
             playExpect(result).toBeFalsy();
           } else {
+            console.log('Expected to pass on Linux, Windows and macOS');
             playExpect(result).toBeTruthy();
           }
         },

--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -136,6 +136,7 @@ describe('BootC Extension', async () => {
           [page, webview] = await handleWebview();
           const bootcPage = new BootcPage(page, webview);
           const result = await bootcPage.buildDiskImage(`${imageName}:${imageTag}`, pathToStore, type, architecture);
+          console.log(`Result: ${result}`);
           console.log(
             `Building disk image for platform ${os.platform()} and architecture ${architecture} and type ${type} is ${result}`,
           );

--- a/tests/playwright/src/model/bootc-page.ts
+++ b/tests/playwright/src/model/bootc-page.ts
@@ -134,7 +134,7 @@ export class BootcPage {
     await this.goBackButton.click();
     await playExpect(this.bootcListPage).toBeVisible();
 
-    await playExpect(this.getTypeOfLatestBuildImage).toContainText(type.toLocaleLowerCase(), { timeout : 10000 });
+    await playExpect(this.getTypeOfLatestBuildImage).toContainText(type.toLocaleLowerCase(), { timeout: 10000 });
     await this.waitUntilCurrentBuildIsFinished();
     if ((await this.getCurrentStatusOfLatestEntry()) === 'error') {
       console.log('Error building image');

--- a/tests/playwright/src/model/bootc-page.ts
+++ b/tests/playwright/src/model/bootc-page.ts
@@ -41,6 +41,7 @@ export class BootcPage {
   readonly getCurrentStatusOfLatestBuildImage: Locator;
   readonly bootcListPage: Locator;
   readonly bootcBuildDiskPage: Locator;
+  readonly getTypeOfLatestBuildImage: Locator;
 
   constructor(page: Page, webview: Page) {
     this.page = page;
@@ -62,6 +63,7 @@ export class BootcPage {
     this.rowGroup = webview.getByRole('rowgroup').nth(1);
     this.latestBuiltImage = this.rowGroup.getByRole('row').first();
     this.getCurrentStatusOfLatestBuildImage = this.latestBuiltImage.getByRole('status');
+    this.getTypeOfLatestBuildImage = this.latestBuiltImage.getByRole('cell').nth(4);
   }
 
   async buildDiskImage(
@@ -132,6 +134,7 @@ export class BootcPage {
     await this.goBackButton.click();
     await playExpect(this.bootcListPage).toBeVisible();
 
+    await playExpect(this.getTypeOfLatestBuildImage).toContainText(type.toLocaleLowerCase(), { timeout : 10000 });
     await this.waitUntilCurrentBuildIsFinished();
     if ((await this.getCurrentStatusOfLatestEntry()) === 'error') {
       console.log('Error building image');

--- a/tests/playwright/src/model/bootc-page.ts
+++ b/tests/playwright/src/model/bootc-page.ts
@@ -138,6 +138,7 @@ export class BootcPage {
     await this.waitUntilCurrentBuildIsFinished();
     if ((await this.getCurrentStatusOfLatestEntry()) === 'error') {
       console.log('Error building image');
+      console.log('Returning false');
       return false;
     }
 

--- a/tests/playwright/src/model/bootc-page.ts
+++ b/tests/playwright/src/model/bootc-page.ts
@@ -146,7 +146,6 @@ export class BootcPage {
     const okButtonLocator = this.page.getByRole('button', { name: 'OK' });
     await playExpect(okButtonLocator).toBeEnabled();
     await okButtonLocator.click();
-    console.log(`Result for building disk image for ${imageName} is ${result}`);
 
     return result;
   }

--- a/tests/playwright/src/model/bootc-page.ts
+++ b/tests/playwright/src/model/bootc-page.ts
@@ -137,8 +137,7 @@ export class BootcPage {
     await playExpect(this.getTypeOfLatestBuildImage).toContainText(type.toLocaleLowerCase(), { timeout: 10000 });
     await this.waitUntilCurrentBuildIsFinished();
     if ((await this.getCurrentStatusOfLatestEntry()) === 'error') {
-      console.log('Error building image');
-      console.log('Returning false');
+      console.log('Error building image! Retuning false.');
       return false;
     }
 


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where the e2e test moves on before the latest build triggered is displayed on bootc page

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-extension-bootc/issues/629
