### PR TITLE
chore(test): remove bootc images before finishing

### DIFF
--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -71,6 +71,7 @@ afterAll(async () => {
   } catch (error) {
     console.log(`Error deleting image: ${error}`);
   } finally {
+    await removeFolderIfExists('tests/output/images');
     await pdRunner.close();
   }
 });


### PR DESCRIPTION
### What does this PR do?
Removes bootc images from e2e tests at the end of the test.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-extension-bootc/issues/659
