### PR TITLE
chore(test): increasing timeout for windows

### DIFF
--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -148,7 +148,7 @@ describe('BootC Extension', async () => {
             playExpect(result).toBeTruthy();
           }
         },
-        350000,
+        620000,
       );
     },
   );

--- a/tests/playwright/src/model/bootc-page.ts
+++ b/tests/playwright/src/model/bootc-page.ts
@@ -176,7 +176,7 @@ export class BootcPage {
         (await this.getCurrentStatusOfLatestEntry()) === 'error' ||
         (await this.getCurrentStatusOfLatestEntry()) === 'success',
       {
-        timeout: 340000,
+        timeout: 600000,
         diff: 2500,
         message: `Build didn't finish before timeout!`,
       },


### PR DESCRIPTION
### What does this PR do?
Increases waiting timeout for build finishing before it takes much longer on windows

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-extension-bootc/issues/629
