### PR TITLE
chore(test): special handling for iso builds

### DIFF
--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -128,12 +128,11 @@ describe('BootC Extension', async () => {
 
       describe.skipIf(isLinux).each(['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO'])('Building images ', async type => {
         test(`Building bootable image type: ${type}`, async context => {
-          if(type === 'ISO'){
-            if(buildISOImage){
+          if (type === 'ISO') {
+            if (buildISOImage) {
               timeoutForBuild = 1200000;
               console.log(`Building ISO image requested, extending timeout to ${timeoutForBuild}`);
-            }
-            else{
+            } else {
               console.log(`Building ISO image not requested, skipping test`);
               context.skip();
             }
@@ -148,7 +147,13 @@ describe('BootC Extension', async () => {
           const pathToStore = path.resolve(__dirname, '..', 'tests', 'output', 'images', `${type}-${architecture}`);
           [page, webview] = await handleWebview();
           const bootcPage = new BootcPage(page, webview);
-          const result = await bootcPage.buildDiskImage(`${imageName}:${imageTag}`, pathToStore, type, architecture, timeoutForBuild);
+          const result = await bootcPage.buildDiskImage(
+            `${imageName}:${imageTag}`,
+            pathToStore,
+            type,
+            architecture,
+            timeoutForBuild,
+          );
           console.log(
             `Building disk image for platform ${os.platform()} and architecture ${architecture} and type ${type} is ${result}`,
           );

--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -48,6 +48,8 @@ const isWindows = os.platform() === 'win32';
 const containerFilePath = path.resolve(__dirname, '..', 'resources', 'bootable-containerfile');
 const contextDirectory = path.resolve(__dirname, '..', 'resources');
 const skipInstallation = process.env.SKIP_INSTALLATION;
+const buildISOImage = process.env.BUILD_ISO_IMAGE;
+let timeoutForBuild = 600000;
 
 beforeEach<RunnerTestContext>(async ctx => {
   ctx.pdRunner = pdRunner;
@@ -124,9 +126,19 @@ describe('BootC Extension', async () => {
         await playExpect.poll(async () => await imagesPage.waitForImageExists(imageName)).toBeTruthy();
       }, 150000);
 
-      test.skipIf(isLinux).each(['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO'])(
-        `Building bootable image type: %s`,
-        async type => {
+      describe.skipIf(isLinux).each(['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO'])('Building images ', async type => {
+        test(`Building bootable image type: ${type}`, async context => {
+          if(type === 'ISO'){
+            if(buildISOImage){
+              timeoutForBuild = 1200000;
+              console.log(`Building ISO image requested, extending timeout to ${timeoutForBuild}`);
+            }
+            else{
+              console.log(`Building ISO image not requested, skipping test`);
+              context.skip();
+            }
+          }
+
           const imagesPage = await navBar.openImages();
           await playExpect(imagesPage.heading).toBeVisible();
 
@@ -136,7 +148,7 @@ describe('BootC Extension', async () => {
           const pathToStore = path.resolve(__dirname, '..', 'tests', 'output', 'images', `${type}-${architecture}`);
           [page, webview] = await handleWebview();
           const bootcPage = new BootcPage(page, webview);
-          const result = await bootcPage.buildDiskImage(`${imageName}:${imageTag}`, pathToStore, type, architecture);
+          const result = await bootcPage.buildDiskImage(`${imageName}:${imageTag}`, pathToStore, type, architecture, timeoutForBuild);
           console.log(
             `Building disk image for platform ${os.platform()} and architecture ${architecture} and type ${type} is ${result}`,
           );
@@ -147,9 +159,8 @@ describe('BootC Extension', async () => {
             console.log('Expected to pass on Linux, Windows and macOS');
             playExpect(result).toBeTruthy();
           }
-        },
-        620000,
-      );
+        }, 1250000);
+      });
     },
   );
 

--- a/tests/playwright/src/model/bootc-page.ts
+++ b/tests/playwright/src/model/bootc-page.ts
@@ -20,6 +20,7 @@ import type { Locator, Page } from '@playwright/test';
 import { expect as playExpect } from '@playwright/test';
 import { waitUntil } from '@podman-desktop/tests-playwright';
 import { ArchitectureType } from '@podman-desktop/tests-playwright';
+import { time } from 'node:console';
 
 export class BootcPage {
   readonly page: Page;
@@ -71,6 +72,7 @@ export class BootcPage {
     pathToStore: string,
     type: string,
     architecture: ArchitectureType,
+    timeout = 600000,
   ): Promise<boolean> {
     let result = false;
 
@@ -135,7 +137,7 @@ export class BootcPage {
     await playExpect(this.bootcListPage).toBeVisible();
 
     await playExpect(this.getTypeOfLatestBuildImage).toContainText(type.toLocaleLowerCase(), { timeout: 10000 });
-    await this.waitUntilCurrentBuildIsFinished();
+    await this.waitUntilCurrentBuildIsFinished(timeout);
     if ((await this.getCurrentStatusOfLatestEntry()) === 'error') {
       console.log('Error building image! Retuning false.');
       return false;
@@ -170,13 +172,13 @@ export class BootcPage {
     return '';
   }
 
-  async waitUntilCurrentBuildIsFinished(): Promise<void> {
+  async waitUntilCurrentBuildIsFinished(timeout = 600000): Promise<void> {
     await waitUntil(
       async () =>
         (await this.getCurrentStatusOfLatestEntry()) === 'error' ||
         (await this.getCurrentStatusOfLatestEntry()) === 'success',
       {
-        timeout: 600000,
+        timeout: timeout,
         diff: 2500,
         message: `Build didn't finish before timeout!`,
       },

--- a/tests/playwright/src/model/bootc-page.ts
+++ b/tests/playwright/src/model/bootc-page.ts
@@ -131,9 +131,9 @@ export class BootcPage {
     await this.buildButton.focus();
     await this.buildButton.click();
 
-    await playExpect(this.goBackButton).toBeEnabled();
+    await playExpect(this.goBackButton).toBeEnabled({ timeout: 30000 });
     await this.goBackButton.click();
-    await playExpect(this.bootcListPage).toBeVisible();
+    await playExpect(this.bootcListPage).toBeVisible({ timeout: 10000 });
 
     await playExpect(this.getTypeOfLatestBuildImage).toContainText(type.toLocaleLowerCase(), { timeout: 10000 });
     await this.waitUntilCurrentBuildIsFinished(timeout);

--- a/tests/playwright/src/model/bootc-page.ts
+++ b/tests/playwright/src/model/bootc-page.ts
@@ -20,7 +20,6 @@ import type { Locator, Page } from '@playwright/test';
 import { expect as playExpect } from '@playwright/test';
 import { waitUntil } from '@podman-desktop/tests-playwright';
 import { ArchitectureType } from '@podman-desktop/tests-playwright';
-import { time } from 'node:console';
 
 export class BootcPage {
   readonly page: Page;


### PR DESCRIPTION
### What does this PR do?
Adds a special flag to build ISO images and increases timeout in such a case, because ISO builds take much longer than others.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-extension-bootc/issues/662