### PR TITLE
chore(test): skip tests if image build failed

### DIFF
--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -50,6 +50,7 @@ const contextDirectory = path.resolve(__dirname, '..', 'resources');
 const skipInstallation = process.env.SKIP_INSTALLATION;
 const buildISOImage = process.env.BUILD_ISO_IMAGE;
 let timeoutForBuild = 600000;
+let imageBuildFailed = true;
 
 beforeEach<RunnerTestContext>(async ctx => {
   ctx.pdRunner = pdRunner;
@@ -110,6 +111,7 @@ describe('BootC Extension', async () => {
     'Bootc images for architecture: %s',
     async architecture => {
       test('Build bootc image from containerfile', async () => {
+        imageBuildFailed = true;
         let imagesPage = await navBar.openImages();
         await playExpect(imagesPage.heading).toBeVisible();
 
@@ -121,12 +123,14 @@ describe('BootC Extension', async () => {
           containerFilePath,
           contextDirectory,
           architecture,
+          180000,
         );
 
         await playExpect.poll(async () => await imagesPage.waitForImageExists(imageName)).toBeTruthy();
-      }, 150000);
+        imageBuildFailed = false;
+      }, 210000);
 
-      describe.skipIf(isLinux).each(['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO'])('Building images ', async type => {
+      describe.skipIf(isLinux || imageBuildFailed).each(['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO'])('Building images ', async type => {
         test(`Building bootable image type: ${type}`, async context => {
           if (type === 'ISO') {
             if (buildISOImage) {

--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -130,46 +130,49 @@ describe('BootC Extension', async () => {
         imageBuildFailed = false;
       }, 210000);
 
-      describe.skipIf(isLinux || imageBuildFailed).each(['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO'])('Building images ', async type => {
-        test(`Building bootable image type: ${type}`, async context => {
-          if (type === 'ISO') {
-            if (buildISOImage) {
-              timeoutForBuild = 1200000;
-              console.log(`Building ISO image requested, extending timeout to ${timeoutForBuild}`);
-            } else {
-              console.log(`Building ISO image not requested, skipping test`);
-              context.skip();
+      describe.skipIf(isLinux || imageBuildFailed).each(['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO'])(
+        'Building images ',
+        async type => {
+          test(`Building bootable image type: ${type}`, async context => {
+            if (type === 'ISO') {
+              if (buildISOImage) {
+                timeoutForBuild = 1200000;
+                console.log(`Building ISO image requested, extending timeout to ${timeoutForBuild}`);
+              } else {
+                console.log(`Building ISO image not requested, skipping test`);
+                context.skip();
+              }
             }
-          }
 
-          const imagesPage = await navBar.openImages();
-          await playExpect(imagesPage.heading).toBeVisible();
+            const imagesPage = await navBar.openImages();
+            await playExpect(imagesPage.heading).toBeVisible();
 
-          const imageDetailPage = await imagesPage.openImageDetails(imageName);
-          await playExpect(imageDetailPage.heading).toBeVisible();
+            const imageDetailPage = await imagesPage.openImageDetails(imageName);
+            await playExpect(imageDetailPage.heading).toBeVisible();
 
-          const pathToStore = path.resolve(__dirname, '..', 'tests', 'output', 'images', `${type}-${architecture}`);
-          [page, webview] = await handleWebview();
-          const bootcPage = new BootcPage(page, webview);
-          const result = await bootcPage.buildDiskImage(
-            `${imageName}:${imageTag}`,
-            pathToStore,
-            type,
-            architecture,
-            timeoutForBuild,
-          );
-          console.log(
-            `Building disk image for platform ${os.platform()} and architecture ${architecture} and type ${type} is ${result}`,
-          );
-          if (isWindows && architecture === ArchitectureType.ARM64) {
-            console.log('Expected to fail on Windows for ARM64');
-            playExpect(result).toBeFalsy();
-          } else {
-            console.log('Expected to pass on Linux, Windows and macOS');
-            playExpect(result).toBeTruthy();
-          }
-        }, 1250000);
-      });
+            const pathToStore = path.resolve(__dirname, '..', 'tests', 'output', 'images', `${type}-${architecture}`);
+            [page, webview] = await handleWebview();
+            const bootcPage = new BootcPage(page, webview);
+            const result = await bootcPage.buildDiskImage(
+              `${imageName}:${imageTag}`,
+              pathToStore,
+              type,
+              architecture,
+              timeoutForBuild,
+            );
+            console.log(
+              `Building disk image for platform ${os.platform()} and architecture ${architecture} and type ${type} is ${result}`,
+            );
+            if (isWindows && architecture === ArchitectureType.ARM64) {
+              console.log('Expected to fail on Windows for ARM64');
+              playExpect(result).toBeFalsy();
+            } else {
+              console.log('Expected to pass on Linux, Windows and macOS');
+              playExpect(result).toBeTruthy();
+            }
+          }, 1250000);
+        },
+      );
     },
   );
 

--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -130,49 +130,51 @@ describe('BootC Extension', async () => {
         imageBuildFailed = false;
       }, 210000);
 
-      describe.skipIf(isLinux || imageBuildFailed).each(['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO'])(
-        'Building images ',
-        async type => {
-          test(`Building bootable image type: ${type}`, async context => {
-            if (type === 'ISO') {
-              if (buildISOImage) {
-                timeoutForBuild = 1200000;
-                console.log(`Building ISO image requested, extending timeout to ${timeoutForBuild}`);
-              } else {
-                console.log(`Building ISO image not requested, skipping test`);
-                context.skip();
-              }
-            }
+      describe.skipIf(isLinux).each(['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO'])('Building images ', async type => {
+        test(`Building bootable image type: ${type}`, async context => {
+          if (imageBuildFailed) {
+            console.log('Image build failed, skipping test');
+            context.skip();
+          }
 
-            const imagesPage = await navBar.openImages();
-            await playExpect(imagesPage.heading).toBeVisible();
-
-            const imageDetailPage = await imagesPage.openImageDetails(imageName);
-            await playExpect(imageDetailPage.heading).toBeVisible();
-
-            const pathToStore = path.resolve(__dirname, '..', 'tests', 'output', 'images', `${type}-${architecture}`);
-            [page, webview] = await handleWebview();
-            const bootcPage = new BootcPage(page, webview);
-            const result = await bootcPage.buildDiskImage(
-              `${imageName}:${imageTag}`,
-              pathToStore,
-              type,
-              architecture,
-              timeoutForBuild,
-            );
-            console.log(
-              `Building disk image for platform ${os.platform()} and architecture ${architecture} and type ${type} is ${result}`,
-            );
-            if (isWindows && architecture === ArchitectureType.ARM64) {
-              console.log('Expected to fail on Windows for ARM64');
-              playExpect(result).toBeFalsy();
+          if (type === 'ISO') {
+            if (buildISOImage) {
+              timeoutForBuild = 1200000;
+              console.log(`Building ISO image requested, extending timeout to ${timeoutForBuild}`);
             } else {
-              console.log('Expected to pass on Linux, Windows and macOS');
-              playExpect(result).toBeTruthy();
+              console.log(`Building ISO image not requested, skipping test`);
+              context.skip();
             }
-          }, 1250000);
-        },
-      );
+          }
+
+          const imagesPage = await navBar.openImages();
+          await playExpect(imagesPage.heading).toBeVisible();
+
+          const imageDetailPage = await imagesPage.openImageDetails(imageName);
+          await playExpect(imageDetailPage.heading).toBeVisible();
+
+          const pathToStore = path.resolve(__dirname, '..', 'tests', 'output', 'images', `${type}-${architecture}`);
+          [page, webview] = await handleWebview();
+          const bootcPage = new BootcPage(page, webview);
+          const result = await bootcPage.buildDiskImage(
+            `${imageName}:${imageTag}`,
+            pathToStore,
+            type,
+            architecture,
+            timeoutForBuild,
+          );
+          console.log(
+            `Building disk image for platform ${os.platform()} and architecture ${architecture} and type ${type} is ${result}`,
+          );
+          if (isWindows && architecture === ArchitectureType.ARM64) {
+            console.log('Expected to fail on Windows for ARM64');
+            playExpect(result).toBeFalsy();
+          } else {
+            console.log('Expected to pass on Linux, Windows and macOS');
+            playExpect(result).toBeTruthy();
+          }
+        }, 1250000);
+      });
     },
   );
 


### PR DESCRIPTION
### What does this PR do?
Checks for initial image build to be finished correctly before trying to use the image afterwards.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-extension-bootc/issues/675
