### PR TITLE
chore(test): increasing timeout for windows e2e tests

### DIFF
--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -49,7 +49,7 @@ const containerFilePath = path.resolve(__dirname, '..', 'resources', 'bootable-c
 const contextDirectory = path.resolve(__dirname, '..', 'resources');
 const skipInstallation = process.env.SKIP_INSTALLATION;
 const buildISOImage = process.env.BUILD_ISO_IMAGE;
-let timeoutForBuild = 600000;
+let timeoutForBuild = 900000;
 let imageBuildFailed = true;
 
 beforeEach<RunnerTestContext>(async ctx => {


### PR DESCRIPTION
### What does this PR do?
Increases timeout for waiting on build finish due to slow build time on azure machines

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-extension-bootc/issues/690