### PR TITLE
chore(test): adjusting timeout in afterAll hook

### DIFF
--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -77,7 +77,7 @@ afterAll(async () => {
     await removeFolderIfExists('tests/output/images');
     await pdRunner.close();
   }
-});
+}, 180000);
 
 describe('BootC Extension', async () => {
   test('Go to settings and check if extension is already installed', async () => {


### PR DESCRIPTION
### What does this PR do?
Adjusts timeout in afterAll hook of e2e tests

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-extension-bootc/pull/689
