### PR TITLE
chore: add debugging / error information to log file as well

### DIFF
--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -280,6 +280,11 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History, ov
           errorMessage = (error as Error).message;
           console.error(error);
           telemetryData.error = error;
+
+          // Append the error to the file as well for debugging purposes, but do not worry if it fails / errors out the build.
+          await fs.promises.appendFile(logPath, errorMessage).catch((error: unknown) => {
+            console.debug('Could not write error to bootc build log: ', error);
+          });
         } finally {
           // ###########
           // # CLEANUP #


### PR DESCRIPTION
chore: add debugging / error information to log file as well

### What does this PR do?

Adds some simple code that also outputs any errors with the function to
the log file for debugging purposes / being able to help for any
debugging.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/678

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Before pressing build, stop your Podman Machine
2. See that it outputs the connection error into the build log file.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
