### PR TITLE
feat: adds log page for builds

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -100,6 +100,8 @@
     "@typescript-eslint/eslint-plugin": "^8.5.0",
     "@typescript-eslint/parser": "^6.16.0",
     "@vitest/coverage-v8": "^2.0.2",
+    "@xterm/xterm": "^5.5.0",
+    "@xterm/addon-fit": "^0.10.0",
     "eslint": "^8.56.0",
     "eslint-import-resolver-custom-alias": "^1.3.2",
     "eslint-import-resolver-typescript": "^3.6.3",

--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -263,15 +263,11 @@ export class BootcApiImpl implements BootcApi {
   // Get configuration values from Podman Desktop
   // specifically we do this so we can obtain the setting for terminal font size
   // returns "any" because the configuration values are not typed
-  async getUserConfigurationValue(config: string, section: string): Promise<unknown> {
+  async getConfigurationValue(config: string, section: string): Promise<unknown> {
     try {
-      console.log('going to try and get configuration value: ', config);
-      const value = podmanDesktopApi.configuration.getConfiguration(config).get(section);
-      console.log('Configuration value:getConfiguration', value);
-      return value;
+      return podmanDesktopApi.configuration.getConfiguration(config).get(section);
     } catch (err) {
-      await podmanDesktopApi.window.showErrorMessage(`Error getting configuration: ${err}`);
-      console.error('Error getting configuration: ', err);
+      console.error('Error getting configuration, will return undefined: ', err);
     }
     return undefined;
   }

--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -26,6 +26,8 @@ import * as containerUtils from './container-utils';
 import { Messages } from '/@shared/src/messages/Messages';
 import { telemetryLogger } from './extension';
 import { checkPrereqs, isLinux, getUidGid } from './machine-utils';
+import * as fs from 'node:fs';
+import path from 'node:path';
 import { getContainerEngine } from './container-utils';
 
 export class BootcApiImpl implements BootcApi {
@@ -247,6 +249,31 @@ export class BootcApiImpl implements BootcApi {
 
   async getUidGid(): Promise<string> {
     return getUidGid();
+  }
+
+  async loadLogsFromFolder(folder: string): Promise<string> {
+    // Combine folder name  and image-build.log
+    const filePath = path.join(folder, 'image-build.log');
+
+    // Simply try to the read the file and return the contents, must use utf8 formatting
+    // to ensure the file is read properly / no ascii characters.
+    return fs.readFileSync(filePath, 'utf8');
+  }
+
+  // Get configuration values from Podman Desktop
+  // specifically we do this so we can obtain the setting for terminal font size
+  // returns "any" because the configuration values are not typed
+  async getUserConfigurationValue(config: string, section: string): Promise<unknown> {
+    try {
+      console.log('going to try and get configuration value: ', config);
+      const value = podmanDesktopApi.configuration.getConfiguration(config).get(section);
+      console.log('Configuration value:getConfiguration', value);
+      return value;
+    } catch (err) {
+      await podmanDesktopApi.window.showErrorMessage(`Error getting configuration: ${err}`);
+      console.error('Error getting configuration: ', err);
+    }
+    return undefined;
   }
 
   // The API does not allow callbacks through the RPC, so instead

--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -9,6 +9,7 @@ import { getRouterState } from './api/client';
 import Homepage from './Homepage.svelte';
 import { rpcBrowser } from '/@/api/client';
 import { Messages } from '/@shared/src/messages/Messages';
+import Logs from './Logs.svelte';
 
 router.mode.hash();
 
@@ -34,6 +35,11 @@ onMount(() => {
       </Route>
       <Route path="/build" breadcrumb="Build">
         <Build />
+      </Route>
+      <Route path="/logs/:base64BuildImageName/:base64FolderLocation" breadcrumb="Logs" let:meta>
+        <Logs
+          base64BuildImageName={meta.params.base64BuildImageName}
+          base64FolderLocation={meta.params.base64FolderLocation} />
       </Route>
       <Route path="/build/:name/:tag" breadcrumb="Build" let:meta>
         <Build imageName={decodeURIComponent(meta.params.name)} imageTag={decodeURIComponent(meta.params.tag)} />

--- a/packages/frontend/src/Logs.spec.ts
+++ b/packages/frontend/src/Logs.spec.ts
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { vi, test, expect, beforeAll } from 'vitest';
+import Logs from './Logs.svelte';
+import { bootcClient } from './api/client';
+
+vi.mock('./api/client', async () => ({
+  bootcClient: {
+    loadLogsFromFolder: vi.fn(),
+    getUserConfigurationValue: vi.fn(),
+  },
+}));
+
+beforeAll(() => {
+  (window as any).ResizeObserver = ResizeObserver;
+  (window as any).getConfigurationValue = vi.fn().mockResolvedValue(undefined);
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    addListener: vi.fn(),
+  });
+
+  Object.defineProperty(window, 'matchMedia', {
+    value: () => {
+      return {
+        matches: false,
+        addListener: () => {},
+        removeListener: () => {},
+      };
+    },
+  });
+});
+
+class ResizeObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+}
+
+const mockLogs = `Build log line 1
+Build log line 2
+Build log line 3`;
+
+test('Render logs and terminal setup', async () => {
+  vi.mocked(bootcClient.loadLogsFromFolder).mockResolvedValue(mockLogs);
+  vi.mocked(bootcClient.getUserConfigurationValue).mockResolvedValue(14);
+
+  const base64FolderLocation = btoa('/path/to/logs');
+  const base64BuildImageName = btoa('test-image');
+
+  render(Logs, { base64FolderLocation, base64BuildImageName });
+
+  // Wait for the logs to be shown
+  await waitFor(() => {
+    expect(bootcClient.loadLogsFromFolder).toHaveBeenCalledWith('/path/to/logs');
+    expect(screen.queryByText('Build log line 1')).toBeDefined();
+    expect(screen.queryByText('Build log line 2')).toBeDefined();
+    expect(screen.queryByText('Build log line 3')).toBeDefined();
+  });
+});
+
+test('Handles empty logs correctly', async () => {
+  vi.mocked(bootcClient.loadLogsFromFolder).mockResolvedValue('');
+  vi.mocked(bootcClient.getUserConfigurationValue).mockResolvedValue(14);
+
+  const base64FolderLocation = btoa('/empty/logs');
+  const base64BuildImageName = btoa('empty-image');
+
+  render(Logs, { base64FolderLocation, base64BuildImageName });
+
+  // Verify no logs message is displayed when logs are empty
+  const emptyMessage = await screen.findByText(/Unable to read image-build.log file from \/empty\/logs/);
+  expect(emptyMessage).toBeDefined();
+});

--- a/packages/frontend/src/Logs.spec.ts
+++ b/packages/frontend/src/Logs.spec.ts
@@ -23,7 +23,7 @@ import { bootcClient } from './api/client';
 vi.mock('./api/client', async () => ({
   bootcClient: {
     loadLogsFromFolder: vi.fn(),
-    getUserConfigurationValue: vi.fn(),
+    getConfigurationValue: vi.fn(),
   },
 }));
 
@@ -57,7 +57,7 @@ Build log line 3`;
 
 test('Render logs and terminal setup', async () => {
   vi.mocked(bootcClient.loadLogsFromFolder).mockResolvedValue(mockLogs);
-  vi.mocked(bootcClient.getUserConfigurationValue).mockResolvedValue(14);
+  vi.mocked(bootcClient.getConfigurationValue).mockResolvedValue(14);
 
   const base64FolderLocation = btoa('/path/to/logs');
   const base64BuildImageName = btoa('test-image');
@@ -75,7 +75,7 @@ test('Render logs and terminal setup', async () => {
 
 test('Handles empty logs correctly', async () => {
   vi.mocked(bootcClient.loadLogsFromFolder).mockResolvedValue('');
-  vi.mocked(bootcClient.getUserConfigurationValue).mockResolvedValue(14);
+  vi.mocked(bootcClient.getConfigurationValue).mockResolvedValue(14);
 
   const base64FolderLocation = btoa('/empty/logs');
   const base64BuildImageName = btoa('empty-image');

--- a/packages/frontend/src/Logs.svelte
+++ b/packages/frontend/src/Logs.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+import '@xterm/xterm/css/xterm.css';
+
+import { DetailsPage, EmptyScreen, FormPage } from '@podman-desktop/ui-svelte';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
+import { onDestroy, onMount } from 'svelte';
+import { router } from 'tinro';
+import DiskImageIcon from './lib/DiskImageIcon.svelte';
+import { bootcClient } from './api/client';
+import { getTerminalTheme } from './lib/upstream/terminal-theme';
+
+export let base64FolderLocation: string;
+export let base64BuildImageName: string;
+
+// Decode the base64 folder location to a normal string path
+const folderLocation = atob(base64FolderLocation);
+const buildImageName = atob(base64BuildImageName);
+
+// Log
+let logsXtermDiv: HTMLDivElement;
+let noLogs = true;
+let previousLogs: string = '';
+const refreshInterval = 2000;
+
+// Terminal resize
+let resizeObserver: ResizeObserver;
+let termFit: FitAddon;
+
+let logsTerminal: Terminal;
+let logInterval: NodeJS.Timeout;
+
+async function fetchFolderLogs() {
+  const logs = await bootcClient.loadLogsFromFolder(folderLocation);
+
+  // We will write only the new logs to the terminal,
+  // this is a simple way of updating the logs as we update it by calling the function
+  // every 2 seconds instead of setting up a file watcher (unable to do so through RPC calls, due to long-running process)
+  if (logs !== previousLogs) {
+    // Write only the new logs to the log
+    const newLogs = logs.slice(previousLogs.length);
+    logsTerminal.write(newLogs);
+    previousLogs = logs; // Update the stored logs
+    noLogs = false; // Make sure that the logs are visible
+  }
+}
+
+async function refreshTerminal() {
+  // missing element, return
+  if (!logsXtermDiv) {
+    console.log('missing xterm div, exiting...');
+    return;
+  }
+
+  // Retrieve the user configuration settings for the terminal to match the rest of Podman Desktop.
+  const fontSize = (await bootcClient.getUserConfigurationValue('terminal', 'integrated.fontSize')) as number;
+  const lineHeight = (await bootcClient.getUserConfigurationValue('terminal', 'integrated.lineHeight')) as number;
+
+  logsTerminal = new Terminal({
+    fontSize: fontSize,
+    lineHeight: lineHeight,
+    disableStdin: true,
+    theme: getTerminalTheme(),
+    convertEol: true,
+  });
+  termFit = new FitAddon();
+  logsTerminal.loadAddon(termFit);
+
+  logsTerminal.open(logsXtermDiv);
+
+  // Disable cursor as we are just reading the logs
+  logsTerminal.write('\x1b[?25l');
+
+  // Call fit addon each time we resize the window
+  window.addEventListener('resize', () => {
+    termFit.fit();
+  });
+  termFit.fit();
+}
+
+onMount(async () => {
+  // Refresh the terminal on initial load
+  await refreshTerminal();
+
+  // Fetch logs initially and set up the interval to run every 2 seconds
+  // we do this to avoid having to setup a file watcher since long-running commands to the backend is
+  // not possible through RPC calls (yet).
+  fetchFolderLogs();
+  logInterval = setInterval(fetchFolderLogs, refreshInterval);
+
+  // Resize the terminal each time we change the div size
+  resizeObserver = new ResizeObserver(() => {
+    termFit?.fit();
+  });
+
+  // Observe the terminal div
+  resizeObserver.observe(logsXtermDiv);
+});
+
+onDestroy(() => {
+  // Cleanup the observer on destroy
+  resizeObserver?.unobserve(logsXtermDiv);
+
+  // Clear the interval when the component is destroyed
+  clearInterval(logInterval);
+});
+
+export function goToHomePage(): void {
+  router.goto('/');
+}
+</script>
+
+<DetailsPage
+  title="{buildImageName} build logs"
+  breadcrumbLeftPart="Bootable Containers"
+  breadcrumbRightPart="{buildImageName} build logs"
+  breadcrumbTitle="Go back to homepage"
+  onclose={goToHomePage}
+  onbreadcrumbClick={goToHomePage}>
+  <DiskImageIcon slot="icon" size="30px" />
+  <svelte:fragment slot="content">
+    <EmptyScreen
+      icon={undefined}
+      title="No log file"
+      message="Unable to read image-build.log file from {folderLocation}"
+      hidden={noLogs === false} />
+
+    <div
+      class="min-w-full flex flex-col"
+      class:invisible={noLogs === true}
+      class:h-0={noLogs === true}
+      class:h-full={noLogs === false}
+      bind:this={logsXtermDiv}>
+    </div>
+  </svelte:fragment>
+</DetailsPage>

--- a/packages/frontend/src/Logs.svelte
+++ b/packages/frontend/src/Logs.svelte
@@ -53,8 +53,8 @@ async function refreshTerminal() {
   }
 
   // Retrieve the user configuration settings for the terminal to match the rest of Podman Desktop.
-  const fontSize = (await bootcClient.getUserConfigurationValue('terminal', 'integrated.fontSize')) as number;
-  const lineHeight = (await bootcClient.getUserConfigurationValue('terminal', 'integrated.lineHeight')) as number;
+  const fontSize = (await bootcClient.getConfigurationValue('terminal', 'integrated.fontSize')) as number;
+  const lineHeight = (await bootcClient.getConfigurationValue('terminal', 'integrated.lineHeight')) as number;
 
   logsTerminal = new Terminal({
     fontSize: fontSize,

--- a/packages/frontend/src/lib/BootcActions.spec.ts
+++ b/packages/frontend/src/lib/BootcActions.spec.ts
@@ -70,3 +70,13 @@ test('Test clicking on delete button', async () => {
 
   expect(spyOnDelete).toHaveBeenCalled();
 });
+
+test('Test clicking on logs button', async () => {
+  render(BootcActions, { object: mockHistoryInfo });
+
+  // Click on logs button
+  const logsButton = screen.getAllByRole('button', { name: 'Build Logs' })[0];
+  logsButton.click();
+
+  expect(window.location.href).toContain('/logs');
+});

--- a/packages/frontend/src/lib/BootcActions.svelte
+++ b/packages/frontend/src/lib/BootcActions.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 import type { BootcBuildInfo } from '/@shared/src/models/bootc';
 import ListItemButtonIcon from './upstream/ListItemButtonIcon.svelte';
-import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faFileAlt, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { router } from 'tinro';
 import { bootcClient } from '../api/client';
 
 export let object: BootcBuildInfo;
@@ -11,6 +12,15 @@ export let detailed = false;
 async function deleteBuild(): Promise<void> {
   await bootcClient.deleteBuilds([object]);
 }
+
+// Navigate to the build
+async function gotoLogs(): Promise<void> {
+  // Convert object.folder to base64
+  const base64FolderLocation = btoa(object.folder);
+  const base64BuildImageName = btoa(object.image);
+  router.goto(`/logs/${base64BuildImageName}/${base64FolderLocation}`);
+}
 </script>
 
+<ListItemButtonIcon title="Build Logs" onClick={() => gotoLogs()} detailed={detailed} icon={faFileAlt} />
 <ListItemButtonIcon title="Delete Build" onClick={() => deleteBuild()} detailed={detailed} icon={faTrash} />

--- a/packages/frontend/src/lib/upstream/terminal-theme.ts
+++ b/packages/frontend/src/lib/upstream/terminal-theme.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ITheme } from '@xterm/xterm';
+
+// Array of strings to extract from the CSS variables
+// we list it here as we cannot infer the properties from the ITheme type at runtime. Another reason is to avoid
+// the conflict with the 'extendedAnsi' string[] array key. We also provide "safer" method of gathering the CSS values.
+const KNOWN_THEME_PROPERTIES = [
+  'foreground',
+  'background',
+  'cursor',
+  'selectionBackground',
+  'selectionForeground',
+  'black',
+  'red',
+  'green',
+  'yellow',
+  'blue',
+  'magenta',
+  'cyan',
+  'white',
+  'brightBlack',
+  'brightRed',
+  'brightGreen',
+  'brightYellow',
+  'brightBlue',
+  'brightMagenta',
+  'brightCyan',
+  'brightWhite',
+] as const;
+
+const TERMINAL_PREFIX = '--pd-terminal-';
+
+// Utility function to get the terminal theme from CSS variables supplied by color-registry
+// we do this by getting the computed style of the root element and extracting the values of the variables
+// that start with the prefix '--pd-terminal-'
+// we then go through all known theme properties of ITheme and assign the values to the theme object
+export function getTerminalTheme(): ITheme | undefined {
+  const root = document.documentElement;
+
+  if (!root) {
+    console.error(
+      'Could not find document.documentElement and was unable to load terminal theme, returning undefined / default theme',
+    );
+    return undefined;
+  }
+
+  // Get the computed style of the root element containing the color-registry variables
+  const computedStyle = window.getComputedStyle(root);
+  const theme: ITheme = {} as ITheme;
+
+  // Extract and assign each property to the theme object from the CSS variables
+  KNOWN_THEME_PROPERTIES.forEach(property => {
+    const cssVar = `${TERMINAL_PREFIX}${property}`;
+
+    // Find the property value, trim it and assign it to the theme object
+    // only if it is not an empty string
+    const propertyValue = computedStyle.getPropertyValue(cssVar).trim();
+    if (propertyValue) {
+      theme[property] = propertyValue;
+    }
+  });
+
+  return theme;
+}

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -38,7 +38,7 @@ export abstract class BootcApi {
   abstract isLinux(): Promise<boolean>;
   abstract getUidGid(): Promise<string>;
   abstract loadLogsFromFolder(folder: string): Promise<string>;
-  abstract getUserConfigurationValue(config: string, section: string): Promise<unknown>;
+  abstract getConfigurationValue(config: string, section: string): Promise<unknown>;
   abstract telemetryLogUsage(eventName: string, data?: Record<string, unknown> | undefined): Promise<void>;
   abstract telemetryLogError(eventName: string, data?: Record<string, unknown> | undefined): Promise<void>;
 }

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -37,6 +37,8 @@ export abstract class BootcApi {
   abstract openLink(link: string): Promise<void>;
   abstract isLinux(): Promise<boolean>;
   abstract getUidGid(): Promise<string>;
+  abstract loadLogsFromFolder(folder: string): Promise<string>;
+  abstract getUserConfigurationValue(config: string, section: string): Promise<unknown>;
   abstract telemetryLogUsage(eventName: string, data?: Record<string, unknown> | undefined): Promise<void>;
   abstract telemetryLogError(eventName: string, data?: Record<string, unknown> | undefined): Promise<void>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,6 +969,16 @@
     loupe "^3.1.1"
     tinyrainbow "^1.2.0"
 
+"@xterm/addon-fit@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.10.0.tgz#bebf87fadd74e3af30fdcdeef47030e2592c6f55"
+  integrity sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==
+
+"@xterm/xterm@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-5.5.0.tgz#275fb8f6e14afa6e8a0c05d4ebc94523ff775396"
+  integrity sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -3736,16 +3746,7 @@ std-env@^3.7.0:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.7.0.tgz#c9f7386ced6ecf13360b6c6c55b8aaa4ef7481d2"
   integrity sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3782,14 +3783,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4353,16 +4347,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
feat: adds log page for builds

### What does this PR do?

* Adds a log action button that will show the logs in real-time in a
  separate page
* Automatically refreshes / appends to the output
* Uses terminal settings from Podman Desktop to match what the user has
  setup.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/user-attachments/assets/d440a86a-dee7-46cf-9aef-84aa1e3298d9


https://github.com/user-attachments/assets/05d6b51f-80c3-4717-8b40-dff1df61ea49



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/677

### How to test this PR?

1. Start a build
2. Click the "logs" button on the dashboard
3. Watch logs propagate

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
