### PR TITLE
chore: add iso validation when building

### DIFF
--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -132,9 +132,9 @@ test('Render shows correct images and history', async () => {
   expect(select.children[1].textContent).toEqual('image2:latest');
 
   // Expect input iso to be selected
-  const iso = screen.getByLabelText('iso-checkbox');
-  expect(iso).toBeDefined();
-  expect(iso).toBeChecked();
+  const raw = screen.getByLabelText('raw-checkbox');
+  expect(raw).toBeDefined();
+  expect(raw).toBeChecked();
 
   // Expect input amd64 to be selected
   const x86_64 = screen.getByLabelText('amd64-select');
@@ -739,9 +739,19 @@ test('select anaconda-iso and qcow2 and expect validation error to be shown', as
     await new Promise(resolve => setTimeout(resolve, 100));
   }
 
+  // Unclick raw checkbox as it's the default from history
+  const raw = screen.getByLabelText('raw-checkbox');
+  raw.click();
+
   // Get checkbox 'iso-checkbox' and click it.
   const iso = screen.getByLabelText('iso-checkbox');
   iso.click();
+
+  // Give time to propagate the changes
+  await new Promise(resolve => setTimeout(resolve, 300));
+
+  // Expect 'alert' to not be there
+  expect(screen.queryByRole('alert')).toBeNull();
 
   // Get checkbox 'qcow2-checkbox' and click it.
   const qcow2 = screen.getByLabelText('qcow2-checkbox');
@@ -750,8 +760,13 @@ test('select anaconda-iso and qcow2 and expect validation error to be shown', as
   // Give time to propagate the changes
   await new Promise(resolve => setTimeout(resolve, 300));
 
-  // Expect Architecture must be selected to be shown
+  // Expect alert to be shown
   const validation = screen.getByRole('alert');
   expect(validation).toBeDefined();
-  expect(validation.textContent).toEqual('Anaconda ISO must be the only disk image type selected when building an ISO');
+  expect(validation.textContent).toEqual(
+    'The Anaconda ISO file format cannot be built simultaneously with other image types.',
+  );
+
+  // Give time to propagate the changes
+  await new Promise(resolve => setTimeout(resolve, 300));
 });

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -168,6 +168,13 @@ async function validate() {
     return;
   }
 
+  // If anaconda-iso was selected and the buildType length is more than 1, we error saying that iso must be the only type selected.
+  if (buildType.length > 1 && buildType.includes('anaconda-iso')) {
+    errorFormValidation = 'Anaconda ISO must be the only disk image type selected when building an ISO';
+    existingBuild = false;
+    return;
+  }
+
   // overwrite
   existingBuild = await bootcClient.buildExists(buildFolder, buildType);
   if (existingBuild && !overwrite) {

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -170,7 +170,7 @@ async function validate() {
 
   // If anaconda-iso was selected and the buildType length is more than 1, we error saying that iso must be the only type selected.
   if (buildType.length > 1 && buildType.includes('anaconda-iso')) {
-    errorFormValidation = 'Anaconda ISO must be the only disk image type selected when building an ISO';
+    errorFormValidation = 'The Anaconda ISO file format cannot be built simultaneously with other image types.';
     existingBuild = false;
     return;
   }


### PR DESCRIPTION
chore: add iso validation when building

### What does this PR do?

* Adds validation that checks if anaconda-iso and another type has been
  selected, and errors out / shows a warning

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/user-attachments/assets/be31131c-1031-4e52-8800-1eac5572990c



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/702

### How to test this PR?

<!-- Please explain steps to reproduce -->

Try to select iso while another is selected (qcow2, iso, etc.)

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
