### PR TITLE
feat: add vhd option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Go from a [bootc](https://containers.github.io/bootc/) compatible derived contai
 * `raw`: RAW disk image an MBR or GPT partition table
 * `anaconda-iso`: Unattended installation method (USB sticks / install-on-boot)
 * `vmdk`: Usable in vSphere
+* `vhd`: Virtual Hard Disk
 
 The list above is what is supported by the underlying `bootc-image-builder` technology. The list can [be found here](https://github.com/osbuild/bootc-image-builder?tab=readme-ov-file#-image-types).
 

--- a/docs/vm_guide.md
+++ b/docs/vm_guide.md
@@ -13,6 +13,7 @@ There are **many** solutions to deploy a virtual machine image and this document
 * `anaconda-iso`: BalenaEtcher is recommended for writing unattended ISO installer files to storage devices to create bootable media. It's user-friendly and cross-platform. [Download balenaEtcher](https://www.balena.io/etcher/).
 * `vmdk`: VMware Workstation and VMware ESXi are two prominent platforms that support the VMDK format. They provide comprehensive tools for running and managing virtual machines. [VMware Workstation](https://www.vmware.com/products/workstation-pro.html), [VMware ESXi](https://www.vmware.com/products/esxi-and-esx.html).
 * `ami`: Amazon EC2 uses the AMI format to launch new virtual servers. You can manage AMIs using Amazon's own tools like AWS Management Console. [Amazon EC2](https://aws.amazon.com/ec2/).
+* `vhd`: Usable on multiple applications such as Microsoft Hyper-V and Azure.
 
 ## Recommended Development & Testing
 

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -43,6 +43,8 @@ export async function buildExists(folder: string, types: BuildType[]) {
       imageName = 'vmdk/disk.vmdk';
     } else if (type === 'anaconda-iso') {
       imageName = 'bootiso/disk.iso';
+    } else if (type === 'vhd') {
+      imageName = 'vpc/disk.vhd';
     }
 
     const imagePath = resolve(folder, imageName);

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -19,5 +19,5 @@
 // Image related
 export const bootcImageBuilder = 'bootc-image-builder';
 export const bootcImageBuilderCentos =
-  'quay.io/centos-bootc/bootc-image-builder:sha256-516b2ec3feef2c960e7deb13d0c7d50a13a5f56215cae74ead3de860717d0d63';
+  'quay.io/centos-bootc/bootc-image-builder:sha256-8ef91986f03df5607a829a819aa35cf704727609f7656edc413c6e4d145293d1';
 export const bootcImageBuilderRHEL = 'registry.redhat.io/rhel9/bootc-image-builder:9.4';

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -558,6 +558,12 @@ export function goToHomePage(): void {
                   on:click={e => updateBuildType('ami', e.detail)}>
                   Amazon Machine Image (*.ami)
                 </Checkbox>
+                <Checkbox
+                  checked={buildType.includes('vhd')}
+                  title="vhd-checkbox"
+                  on:click={e => updateBuildType('vhd', e.detail)}>
+                  Virtual Hard Disk (*.vhd)
+                </Checkbox>
               </div>
             </div>
             <div>

--- a/packages/shared/src/models/bootc.ts
+++ b/packages/shared/src/models/bootc.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export type BuildType = 'qcow2' | 'ami' | 'raw' | 'vmdk' | 'anaconda-iso';
+export type BuildType = 'qcow2' | 'ami' | 'raw' | 'vmdk' | 'anaconda-iso' | 'vhd';
 
 export interface BootcBuildInfo {
   id: string;

--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -125,7 +125,7 @@ test.describe('BootC Extension', () => {
         imageBuildFailed = false;
       });
 
-      const types = ['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO'];
+      const types = ['QCOW2', 'AMI', 'RAW', 'VMDK', 'ISO', 'VHD'];
 
       for (const type of types) {
         test.describe.serial('Building images ', () => {


### PR DESCRIPTION
feat: add vhd option

### What does this PR do?

* Adds option for vhd / vpc images to be used on Hyper-V or Azure

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/user-attachments/assets/a88f32f8-8037-4564-8af6-3e5759fe1b1a


https://github.com/user-attachments/assets/ab2004ac-ad83-49f5-a0a2-e3aaf8425717




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/799

### How to test this PR?

1. Build a vhd
2. See it completes build correctly.
3. Launch via Hyper-V or Azure / other software

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
