### PR TITLE
chore: svelte should only be in frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "*.{md,css,json}": "prettier --write"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.7.0",
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
+    "@typescript-eslint/eslint-plugin": "^8.7.0",
     "@typescript-eslint/parser": "^8.0.1",
     "@vitest/coverage-v8": "^2.0.2",
     "autoprefixer": "^10.4.20",
@@ -60,8 +60,6 @@
     "lint-staged": "^15.2.10",
     "prettier": "^3.3.3",
     "prettier-plugin-svelte": "^3.2.7",
-    "svelte": "5.0.0-next.260",
-    "svelte-check": "^4.0.3",
     "typescript": "5.6.2",
     "vite": "^5.4.8",
     "vitest": "^2.0.2"

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -13,9 +13,11 @@
     "format:fix": "prettier --write \"src/**/*.{ts,svelte}\"",
     "lint:check": "eslint . --ext js,ts,tsx",
     "lint:fix": "eslint . --fix --ext js,ts,tsx",
+    "svelte:check": "svelte-check --tsconfig ./tsconfig.json",
     "watch": "vite --mode development build -w"
   },
   "dependencies": {
+    "svelte-check": "^4.0.3",
     "svelte-preprocess": "^6.0.3",
     "tinro": "^0.6.12"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,12 +73,6 @@ importers:
       prettier-plugin-svelte:
         specifier: ^3.2.7
         version: 3.2.7(prettier@3.3.3)(svelte@5.0.0-next.260)
-      svelte:
-        specifier: 5.0.0-next.260
-        version: 5.0.0-next.260
-      svelte-check:
-        specifier: ^4.0.3
-        version: 4.0.3(svelte@5.0.0-next.260)(typescript@5.6.2)
       typescript:
         specifier: 5.6.2
         version: 5.6.2
@@ -155,6 +149,9 @@ importers:
 
   packages/frontend:
     dependencies:
+      svelte-check:
+        specifier: ^4.0.3
+        version: 4.0.3(svelte@5.0.0-next.260)(typescript@5.6.2)
       svelte-preprocess:
         specifier: ^6.0.3
         version: 6.0.3(@babel/core@7.24.3)(postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.47)(yaml@2.5.1))(postcss@8.4.47)(svelte@5.0.0-next.260)(typescript@5.6.2)


### PR DESCRIPTION
### What does this PR do?

Removes svelte/svelte-check from the root workspace, as it should only be a frontend dependency.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

PR build.