### PR TITLE
fix: missing component styling

### DIFF
--- a/packages/frontend/tailwind.config.cjs
+++ b/packages/frontend/tailwind.config.cjs
@@ -22,7 +22,7 @@ module.exports = {
   content: [
     'index.html',
     'src/**/*.{svelte,ts,css}',
-    '../../node_modules/@podman-desktop/ui-svelte/src/**/*.{svelte,ts,css}',
+    '../../node_modules/@podman-desktop/ui-svelte/dist/**/*.{svelte,ts,css}',
   ],
   darkMode: 'class',
   theme: {


### PR DESCRIPTION
### What does this PR do?

After a hint from @axel7083 I noticed the bootc frontend Tailwind config is dependent on source in ui-svelte, which is no longer there in recent builds. Switch to dist instead.

### Screenshot / video of UI

Before: missing colors, css.
After: same as before.

### What issues does this PR fix or reference?

Fixes #907.

### How to test this PR?

Check main page looks normal again.