### PR TITLE
chore: fix links on build page

### DIFF
--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -14,7 +14,8 @@ import { onMount } from 'svelte';
 import type { ImageInfo, ManifestInspectInfo } from '@podman-desktop/api';
 import { router } from 'tinro';
 import DiskImageIcon from './lib/DiskImageIcon.svelte';
-import { Button, Input, EmptyScreen, FormPage, Checkbox, Link, ErrorMessage } from '@podman-desktop/ui-svelte';
+import { Button, Input, EmptyScreen, FormPage, Checkbox, ErrorMessage } from '@podman-desktop/ui-svelte';
+import Link from './lib/Link.svelte';
 
 export let imageName: string | undefined = undefined;
 export let imageTag: string | undefined = undefined;


### PR DESCRIPTION
chore: fix links on build page

### What does this PR do?

We were incorrectly using Links from the UI which unfortunatley does not
work (does extra call to external link).

Use `Link` that we've been using in the empty page, etc.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/user-attachments/assets/4c2969d2-31ec-45c8-9983-616eff735309



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-bootc/issues/910

### How to test this PR?

<!-- Please explain steps to reproduce -->

Links on build page work now.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
