### PR TITLE
chore: always pass empty body to notify message

### DIFF
--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -275,7 +275,7 @@ export class BootcApiImpl implements BootcApi {
   // The API does not allow callbacks through the RPC, so instead
   // we send "notify" messages to the frontend to trigger a refresh
   // this method is internal and meant to be used by the API implementation
-  protected async notify(msg: string, body: unknown): Promise<void> {
+  protected async notify(msg: string, body: unknown = {}): Promise<void> {
     await this.webview.postMessage({
       id: msg,
       // Must pass in an empty body to satisfy the type system, if it is undefined, this fails.

--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -275,11 +275,11 @@ export class BootcApiImpl implements BootcApi {
   // The API does not allow callbacks through the RPC, so instead
   // we send "notify" messages to the frontend to trigger a refresh
   // this method is internal and meant to be used by the API implementation
-  protected async notify(msg: string, body: unknown = {}): Promise<void> {
+  protected async notify(id: string, body: unknown = {}): Promise<void> {
+    // Must pass in an empty body, if it is undefined this fails
     await this.webview.postMessage({
-      id: msg,
-      // Must pass in an empty body to satisfy the type system, if it is undefined, this fails.
-      body: body,
+      id,
+      body,
     });
   }
 }

--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -275,11 +275,11 @@ export class BootcApiImpl implements BootcApi {
   // The API does not allow callbacks through the RPC, so instead
   // we send "notify" messages to the frontend to trigger a refresh
   // this method is internal and meant to be used by the API implementation
-  protected async notify(msg: string, body?: unknown): Promise<void> {
+  protected async notify(msg: string, body: unknown): Promise<void> {
     await this.webview.postMessage({
       id: msg,
       // Must pass in an empty body to satisfy the type system, if it is undefined, this fails.
-      body: body ?? '',
+      body: body,
     });
   }
 }

--- a/packages/backend/src/history/historyNotifier.spec.ts
+++ b/packages/backend/src/history/historyNotifier.spec.ts
@@ -79,6 +79,10 @@ describe('Tests involving a file system change', () => {
     historyMock = new HistoryNotifier({ postMessage: postMessageMock } as unknown as Webview, '/foobar');
     onDidChangeListener();
     expect(postMessageMock).toHaveBeenCalledTimes(1);
+    expect(postMessageMock).toHaveBeenCalledWith({
+      id: 'history-update',
+      body: {},
+    });
   });
 
   test('Expect notify to be called when onDidCreate is triggered', async () => {

--- a/packages/backend/src/history/historyNotifier.ts
+++ b/packages/backend/src/history/historyNotifier.ts
@@ -39,7 +39,7 @@ export class HistoryNotifier implements Disposable {
     await this.webview.postMessage({
       id: Messages.MSG_HISTORY_UPDATE,
       // Must pass in an empty body to satisfy the type system, if it is undefined, this fails.
-      body: '',
+      body: {},
     });
   }
 


### PR DESCRIPTION
### What does this PR do?

Confirmed the error isn't impacting function at all, but use an empty object instead of an empty string to avoid errors in the log.

The code in api-impl.ts had an optional parameter that was always passed, just make the parameter mandatory to avoid the same problem in the future.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #914.

### How to test this PR?

PR checks, or try creating/deleting builds and make sure the notifier error is no longer in the logs.