### PR TITLE
feat: backend for examples catalog

### DIFF
--- a/packages/backend/assets/examples.json
+++ b/packages/backend/assets/examples.json
@@ -1,0 +1,44 @@
+{
+  "version": "1.0",
+  "examples": [
+    {
+      "id": "fedora-httpd",
+      "description": "A simple web server using Apache httpd on Fedora.",
+      "name": "Apache httpd",
+      "repository": "https://gitlab.com/fedora/bootc/examples",
+      "image": "registry.gitlab.com/fedora/bootc/examples/httpd",
+      "tag": "latest",
+      "categories": ["fedora"],
+      "architectures": ["amd64"],
+      "basedir": "httpd"
+    },
+    {
+      "id": "fedora-tailscale",
+      "description": "Tailscale on Fedora, use 'tailscale up' after booting.",
+      "name": "Tailscale",
+      "repository": "https://gitlab.com/fedora/bootc/examples",
+      "image": "registry.gitlab.com/fedora/bootc/examples/tailscale",
+      "tag": "latest",
+      "categories": ["fedora"],
+      "architectures": ["amd64"],
+      "basedir": "tailscale"
+    },
+    {
+      "id": "fedora-podman-systemd",
+      "description": "Container running httpd managed by a systemd unit file.",
+      "name": "Podman systemd",
+      "repository": "https://gitlab.com/fedora/bootc/examples",
+      "image": "registry.gitlab.com/fedora/bootc/examples/app-podman-systemd",
+      "tag": "latest",
+      "categories": ["fedora"],
+      "architectures": ["amd64"],
+      "basedir": "app-podman-systemd"
+    }
+  ],
+  "categories": [
+    {
+      "id": "fedora",
+      "name": "Fedora BootC Images"
+    }
+  ]
+}

--- a/packages/backend/src/api-impl.spec.ts
+++ b/packages/backend/src/api-impl.spec.ts
@@ -48,5 +48,9 @@ test('getExamples should return examplesCatalog', async () => {
 
   // When running get Examples we should return the examplesCatalog (it's exported)
   const result = await bootcApi.getExamples();
+  // Check that the examples and categories are NOT empty
+  expect(result.examples.length).not.toBe(0);
+  expect(result.categories.length).not.toBe(0);
+
   expect(result).toEqual(examplesCatalog as ExamplesList);
 });

--- a/packages/backend/src/api-impl.spec.ts
+++ b/packages/backend/src/api-impl.spec.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test, vi } from 'vitest';
+import examplesCatalog from '../assets/examples.json';
+import type { ExamplesList } from '/@shared/src/models/examples';
+import { BootcApiImpl } from './api-impl';
+import type * as podmanDesktopApi from '@podman-desktop/api';
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    window: {
+      showErrorMessage: vi.fn(),
+    },
+    containerEngine: {
+      listImages: vi.fn(),
+    },
+    env: {
+      openExternal: vi.fn(),
+      createTelemetryLogger: vi.fn(),
+    },
+  };
+});
+
+test('getExamples should return examplesCatalog', async () => {
+  const extensionContextMock = {
+    storagePath: '/fake-path',
+  } as unknown as podmanDesktopApi.ExtensionContext;
+
+  const webviewMock = {} as podmanDesktopApi.Webview;
+
+  const bootcApi = new BootcApiImpl(extensionContextMock, webviewMock);
+
+  // When running get Examples we should return the examplesCatalog (it's exported)
+  const result = await bootcApi.getExamples();
+  expect(result).toEqual(examplesCatalog as ExamplesList);
+});

--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -29,6 +29,8 @@ import { checkPrereqs, isLinux, getUidGid } from './machine-utils';
 import * as fs from 'node:fs';
 import path from 'node:path';
 import { getContainerEngine } from './container-utils';
+import examplesCatalog from '../assets/examples.json';
+import type { ExamplesList } from '/@shared/src/models/examples';
 
 export class BootcApiImpl implements BootcApi {
   private history: History;
@@ -40,6 +42,10 @@ export class BootcApiImpl implements BootcApi {
   ) {
     this.history = new History(extensionContext.storagePath);
     this.webview = webview;
+  }
+
+  async getExamples(): Promise<ExamplesList> {
+    return examplesCatalog as ExamplesList;
   }
 
   async checkPrereqs(): Promise<string | undefined> {

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -18,6 +18,7 @@
 
 import type { BootcBuildInfo, BuildType } from './models/bootc';
 import type { ImageInfo, ImageInspectInfo, ManifestInspectInfo } from '@podman-desktop/api';
+import type { ExamplesList } from './models/examples';
 
 export abstract class BootcApi {
   abstract checkPrereqs(): Promise<string | undefined>;
@@ -37,6 +38,7 @@ export abstract class BootcApi {
   abstract openLink(link: string): Promise<void>;
   abstract isLinux(): Promise<boolean>;
   abstract getUidGid(): Promise<string>;
+  abstract getExamples(): Promise<ExamplesList>;
   abstract loadLogsFromFolder(folder: string): Promise<string>;
   abstract getConfigurationValue(config: string, section: string): Promise<unknown>;
   abstract telemetryLogUsage(eventName: string, data?: Record<string, unknown> | undefined): Promise<void>;

--- a/packages/shared/src/models/examples.ts
+++ b/packages/shared/src/models/examples.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface Category {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+// validator for certain types arm / amd64
+export type ArchitectureType = 'arm64' | 'amd64';
+
+export interface Example {
+  id: string;
+  name: string;
+  categories: string[];
+  description: string;
+  repository: string;
+
+  // List of available architectures to pull wtih the image.
+  architectures?: ArchitectureType[];
+
+  // container image to pull, some may not be available... so make this optional.
+  image?: string;
+
+  // tag, else we will assume 'latest'
+  tag?: string;
+
+  // Optional reference version for the example
+  ref?: string;
+
+  // Will assume 'Containerfile' in the root of the repo.
+  basedir?: string;
+
+  // Marks if it is already pulled or not
+  pulled?: boolean;
+  pullInProgress?: boolean;
+}
+
+export interface ExamplesList {
+  version?: string;
+  examples: Example[];
+  categories: Category[];
+}

--- a/packages/shared/src/models/examples.ts
+++ b/packages/shared/src/models/examples.ts
@@ -30,26 +30,21 @@ export interface Example {
   name: string;
   categories: string[];
   description: string;
+
+  // Git repository to pull from
   repository: string;
 
-  // List of available architectures to pull wtih the image.
+  // List of available architectures to pull with the image.
   architectures?: ArchitectureType[];
 
-  // container image to pull, some may not be available... so make this optional.
+  // Container image to pull, some may not be available... so make this optional.
   image?: string;
 
-  // tag, else we will assume 'latest'
+  // Tag, else we will assume 'latest'
   tag?: string;
-
-  // Optional reference version for the example
-  ref?: string;
 
   // Will assume 'Containerfile' in the root of the repo.
   basedir?: string;
-
-  // Marks if it is already pulled or not
-  pulled?: boolean;
-  pullInProgress?: boolean;
 }
 
 export interface ExamplesList {


### PR DESCRIPTION
feat: backend for examples catalog

### What does this PR do?

Adds the basic backend functionality for the examples catalog.

This adds a JSON file that lists all the currently available examples.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

NOT INCLUDED IN PR. But part of this UI implementation:


https://github.com/user-attachments/assets/9205c5f3-40a6-4def-a4ee-2653c4165c25



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/containers/podman-desktop-extension-bootc/issues/895

### How to test this PR?

<!-- Please explain steps to reproduce -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
