### PR TITLE
chore: switch to public macadam npmjs

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -125,7 +125,7 @@
     "vitest": "^3.1.2"
   },
   "dependencies": {
-    "@crc-org/macadam.js": "0.0.1-202505091153-d597ec3",
+    "@crc-org/macadam.js": "0.0.1-202505091029-52992f0",
     "semver": "^7.7.1"
   }
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -17,7 +17,7 @@
     "watch": "vite --mode development build -w"
   },
   "dependencies": {
-    "@crc-org/macadam.js": "0.0.1-202505091153-d597ec3",
+    "@crc-org/macadam.js": "0.0.1-202505091029-52992f0",
     "svelte-check": "^4.1.6",
     "svelte-preprocess": "^6.0.3",
     "tinro": "^0.6.12"


### PR DESCRIPTION
chore: switch to public macadam npmjs

### What does this PR do?

Switches to using the public macadam npmjs location

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

https://github.com/podman-desktop/extension-bootc/issues/1618

### How to test this PR?

<!-- Please explain steps to reproduce --

Should build normally without .npmrc now.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
