### PR TITLE
chore: fix machine stream close (macadam upstream fix)

### DIFF
--- a/packages/backend/src/macadam/macadam-machine-stream.ts
+++ b/packages/backend/src/macadam/macadam-machine-stream.ts
@@ -98,7 +98,6 @@ export class ProviderConnectionShellAccessImpl implements ProviderConnectionShel
       .on('ready', () => {
         this.#client?.shell((err, stream) => {
           if (err) {
-            console.error(err);
             this.onErrorEmit.fire({ error: err.message });
             return;
           }
@@ -132,7 +131,7 @@ export class ProviderConnectionShellAccessImpl implements ProviderConnectionShel
       onEnd: this.onEnd,
       write: this.write.bind(this),
       resize: this.resize.bind(this),
-      close: this.close,
+      close: this.close.bind(this),
     };
   }
 }


### PR DESCRIPTION
chore: fix machine stream close (macadam upstream fix)

### What does this PR do?

See: https://github.com/redhat-developer/podman-desktop-rhel-ext/pull/194/

With the new changes coming to Podman Desktop for the fix, this also
needs to be added too.

Copying / pasting this into our `macadam-machine-stream.ts` to propagate
the change.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/redhat-developer/podman-desktop-rhel-ext/issues/81

### How to test this PR?

<!-- Please explain steps to reproduce -->

N/A, have to wait for PD changes to propagate:

PR's:
- https://github.com/podman-desktop/podman-desktop/pull/12982
- https://github.com/podman-desktop/podman-desktop/pull/12981

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
