### PR TITLE
chore: add warning when cross-arch build on macOS

### DIFF
--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -977,3 +977,27 @@ test.each([
     expect(disclaimer).toBeNull();
   }
 });
+
+test.each([
+  { platform: 'macOS', shouldShow: true },
+  { platform: 'windows', shouldShow: false },
+  { platform: 'linux', shouldShow: true },
+])('cross-architecture-warning visibility on %s when amd64 is selected', async ({ platform, shouldShow }) => {
+  setupPlatformMocks(platform);
+  render(Build);
+
+  await vi.waitFor(() => {
+    expect(screen.getByLabelText('image-select')?.children.length).toBe(2);
+  });
+
+  const x86_64 = screen.getByLabelText('amd64-select');
+  expect(x86_64).toBeDefined();
+  await userEvent.click(x86_64);
+
+  const warning = screen.queryByTestId('cross-architecture-warning');
+  if (shouldShow) {
+    expect(warning).toBeDefined();
+  } else {
+    expect(warning).toBeNull();
+  }
+});

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -27,6 +27,8 @@ import { goToDiskImages } from './lib/navigation';
 export let imageName: string | undefined = undefined;
 export let imageTag: string | undefined = undefined;
 
+const bootcExtensionGithubUrl = 'https://github.com/podman-desktop/extension-bootc';
+
 // Image variables
 let selectedImage: string | undefined;
 let existingBuild: boolean = false;
@@ -810,6 +812,16 @@ $: if (availableArchitectures) {
                   </label>
                 </li>
               </ul>
+
+              <!-- If AMD64 is selected, and we are on mac, we MUST say
+              that there may be issues with cross-architecture building and to read our README for more information -->
+              {#if isMac && buildArch === 'amd64'}
+                <p class="text-sm text-[var(--pd-state-warning)] pt-2"
+                data-testid="cross-architecture-warning">
+                  Cross-architecture building may not work correctly on macOS. Please refer to our
+                  <Link externalRef={bootcExtensionGithubUrl}>README</Link> for more information.
+                </p>
+              {/if}
               <p class="text-sm text-[var(--pd-content-text)] pt-2">
                 Disk image architecture must match the architecture of the original image. For example, you must have an
                 ARM container image to build an ARM disk image. You can only select the architecture that is detectable


### PR DESCRIPTION
chore: add warning when cross-arch build on macOS

### What does this PR do?

* Adds a warning when building amd64 (we only support mac silicon)
* Tests added to compare on macOS vs Linux and Windows.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

<img width="865" height="226" alt="Screenshot 2025-07-22 at 4 42 00 PM" src="https://github.com/user-attachments/assets/8602aabf-3ee9-4fe9-b869-788f0f44d403" />


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/1735

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Be on macOS silicon
2. Try to build a disk image with amd64
3. See the warning under architecture selection before building.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
