### PR TITLE
chore: update ui-svelte to 1.21

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -27,7 +27,7 @@
     "@fortawesome/free-brands-svg-icons": "^7.0.1",
     "@fortawesome/free-regular-svg-icons": "^7.0.1",
     "@fortawesome/free-solid-svg-icons": "^7.0.1",
-    "@podman-desktop/ui-svelte": "1.18.0-202503071223-ce53e6c5bd4",
+    "@podman-desktop/ui-svelte": "1.21.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.13",

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -561,12 +561,14 @@ $: if (availableArchitectures) {
   inProgress={buildInProgress}
   breadcrumbLeftPart="Disk Images"
   breadcrumbRightPart="Build Disk Image"
-  breadcrumbTitle="Go back to disk images"
   onclose={goToDiskImages}
   onbreadcrumbClick={goToDiskImages}>
-  <DiskImageIcon slot="icon" size="30px" />
+  {#snippet icon()}
+  <DiskImageIcon size="30px" />
+  {/snippet}
 
-  <div slot="content" class="p-5 min-w-full h-fit">
+  {#snippet content()}
+  <div class="p-5 min-w-full h-fit">
     {#if buildErrorMessage}
       <EmptyScreen icon={faTriangleExclamation} title="Error with image build" message={buildErrorMessage}>
         <Button
@@ -1120,4 +1122,5 @@ $: if (availableArchitectures) {
       </div>
     {/if}
   </div>
+  {/snippet}
 </FormPage>

--- a/packages/frontend/src/CreateVM.svelte
+++ b/packages/frontend/src/CreateVM.svelte
@@ -123,12 +123,14 @@ async function createVM(): Promise<void> {
   inProgress={createInProgress}
   breadcrumbLeftPart="Disk Images"
   breadcrumbRightPart="Create Virtual Machine"
-  breadcrumbTitle="Go back to disk images"
   onclose={goToDiskImages}
   onbreadcrumbClick={goToDiskImages}>
-  <DiskImageIcon slot="icon" size="30px" />
+  {#snippet icon()}
+    <DiskImageIcon size="30px" />
+  {/snippet}
 
-  <div slot="content" class="p-5 min-w-full h-fit">
+  {#snippet content()}
+  <div class="p-5 min-w-full h-fit">
     {#if createErrorMessage}
       <EmptyScreen
         icon={faTriangleExclamation}
@@ -225,4 +227,5 @@ async function createVM(): Promise<void> {
       </div>
     {/if}
   </div>
+  {/snippet}
 </FormPage>

--- a/packages/frontend/src/lib/Link.svelte
+++ b/packages/frontend/src/lib/Link.svelte
@@ -5,14 +5,13 @@ import { Link } from '@podman-desktop/ui-svelte';
 import type { Snippet } from 'svelte';
 
 interface Props {
-  title?: string;
   internalRef?: string;
   externalRef?: string;
   folder?: string;
   action?: () => void;
   children?: Snippet;
 }
-let { title, internalRef, externalRef, folder, action, children }: Props = $props();
+let { internalRef, externalRef, folder, action, children }: Props = $props();
 
 async function click(): Promise<void> {
   if (internalRef) {
@@ -27,6 +26,6 @@ async function click(): Promise<void> {
 }
 </script>
 
-<Link title={title} on:click={click}>
+<Link onclick={click}>
   {@render children?.()}
 </Link>

--- a/packages/frontend/src/lib/disk-image/DiskImageDetails.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetails.svelte
@@ -53,20 +53,21 @@ onDestroy(() => {
   title="{diskImage?.image}:{diskImage?.tag}"
   breadcrumbLeftPart="Disk Images"
   breadcrumbRightPart="Disk Image Details"
-  breadcrumbTitle="Go back to disk images"
   onclose={goToDiskImages}
   onbreadcrumbClick={goToDiskImages}>
-  <DiskImageIcon slot="icon" size="30px" />
-  <svelte:fragment slot="actions">
+  {#snippet iconSnippet()}
+    <DiskImageIcon size="30px" />
+  {/snippet}
+  {#snippet actionsSnippet()}
     {#if diskImage}
       <DiskImageActions object={diskImage} detailed={true} />
     {/if}
-  </svelte:fragment>
-  <svelte:fragment slot="tabs">
+  {/snippet}
+  {#snippet tabsSnippet()}
     <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
     <Tab title="Build Log" selected={isTabSelected($router.path, 'build')} url={getTabUrl($router.path, 'build')} />
-  </svelte:fragment>
-  <svelte:fragment slot="content">
+  {/snippet}
+  {#snippet contentSnippet()}
     <Route path="/summary" breadcrumb="Summary">
       <DiskImageDetailsSummary image={diskImage} />
     </Route>
@@ -79,5 +80,5 @@ onDestroy(() => {
         <DiskImageDetailsVirtualMachine build={diskImage} />
       {/if}
     </Route>
-  </svelte:fragment>
+  {/snippet}
 </DetailsPage>

--- a/packages/frontend/src/lib/disk-image/DiskImagesList.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImagesList.svelte
@@ -33,9 +33,9 @@ $effect(() => {
   searchPattern.set(searchTerm);
 });
 
-let history = $state<BootcBuildInfoWithSelected[]>([]);
+let history = $state<BootcBuildInfoUI[]>([]);
 
-interface BootcBuildInfoWithSelected extends BootcBuildInfo {
+interface BootcBuildInfoUI extends BootcBuildInfo {
   selected: boolean;
 }
 
@@ -71,28 +71,28 @@ async function deleteSelectedBuilds(): Promise<void> {
 }
 
 let selectedItemsNumber = $state<number>(0);
-let table = $state<Table>();
+let table = $state<Table<BootcBuildInfoUI>>();
 
 // COLUMNS
-let statusColumn = new TableColumn<BootcBuildInfo>('Status', {
+let statusColumn = new TableColumn<BootcBuildInfoUI>('Status', {
   align: 'center',
   width: '70px',
   renderer: DiskImageColumnStatus,
 });
 
-let imageColumn = new TableColumn<BootcBuildInfo>('Image', {
+let imageColumn = new TableColumn<BootcBuildInfoUI>('Image', {
   width: '2fr',
   renderer: DiskImageColumnImage,
   comparator: (a, b): number => a.image.localeCompare(b.image),
 });
 
-let typeColumn = new TableColumn<BootcBuildInfo, string>('Type', {
+let typeColumn = new TableColumn<BootcBuildInfoUI, string>('Type', {
   renderMapping: (object: BootcBuildInfo): string => object.type.join(),
   renderer: TableSimpleColumn,
   comparator: (a, b): number => a.type.join().localeCompare(b.type.join()),
 });
 
-let archColumn = new TableColumn<BootcBuildInfo, string>('Arch', {
+let archColumn = new TableColumn<BootcBuildInfoUI, string>('Arch', {
   renderMapping: (object: BootcBuildInfo): string => object.arch ?? '',
   renderer: TableSimpleColumn,
   comparator: (a, b): number => {
@@ -119,21 +119,21 @@ const columns = [
   new TableColumn<BootcBuildInfo>('Actions', { align: 'right', renderer: DiskImageColumnActions, overflow: true }),
 ];
 
-const row = new TableRow<BootcBuildInfo>({
+const row = new TableRow<BootcBuildInfoUI>({
   selectable: (_build): boolean => true,
 });
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title="disk images" searchEnabled={true}>
-  <svelte:fragment slot="additional-actions">
+  {#snippet additionalActions()}
   <!-- Only show for macOS and Linux -->
   {#if !isWindows}
     <Button on:click={gotoCreateVMForm} icon={DiskImageIcon} title="Create VM">Create VM</Button>
   {/if}
     <Button on:click={gotoBuild} icon={DiskImageIcon} title="Build">Build</Button>
-  </svelte:fragment>
+  {/snippet}
 
-  <svelte:fragment slot="bottom-additional-actions">
+  {#snippet bottomAdditionalActions()}
     {#if selectedItemsNumber > 0}
       <Button
         on:click={deleteSelectedBuilds}
@@ -142,9 +142,10 @@ const row = new TableRow<BootcBuildInfo>({
         icon={faTrash} />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
-  </svelte:fragment>
+  {/snippet}
 
-  <div class="flex min-w-full h-full" slot="content">
+  {#snippet content()}
+  <div class="flex min-w-full h-full">
     <Table
       kind="disk images"
       bind:this={table}
@@ -164,4 +165,5 @@ const row = new TableRow<BootcBuildInfo>({
       <DiskImageEmptyScreen />
     {/if}
   </div>
+  {/snippet}
 </NavPage>

--- a/packages/frontend/src/lib/examples/ExampleDetails.svelte
+++ b/packages/frontend/src/lib/examples/ExampleDetails.svelte
@@ -37,11 +37,12 @@ onMount(async () => {
   title={example?.name}
   breadcrumbLeftPart="Examples"
   breadcrumbRightPart={example?.name}
-  breadcrumbTitle="Go back to Examples"
   onclose={goToExamplesPage}
   onbreadcrumbClick={goToExamplesPage}>
-  <DiskImageIcon slot="icon" size="30px" />
-  <svelte:fragment slot="content">
+  {#snippet iconSnippet()}
+    <DiskImageIcon size="30px" />
+  {/snippet}
+  {#snippet contentSnippet()}
     <div class="bg-[var(--pd-content-bg)] h-full overflow-y-auto">
       <ExampleDetailsLayout detailsTitle="Example details" detailsLabel="Example details">
         <svelte:fragment slot="content">
@@ -62,5 +63,5 @@ onMount(async () => {
         </svelte:fragment>
       </ExampleDetailsLayout>
     </div>
-  </svelte:fragment>
+  {/snippet}
 </DetailsPage>

--- a/packages/frontend/src/lib/examples/Examples.svelte
+++ b/packages/frontend/src/lib/examples/Examples.svelte
@@ -61,7 +61,8 @@ const groups = $derived.by(() => {
 </script>
 
 <NavPage title="Examples" searchEnabled={false}>
-  <div slot="content" class="flex flex-col min-w-full min-h-full">
+  {#snippet content()}
+  <div class="flex flex-col min-w-full min-h-full">
     <div class="min-w-full min-h-full flex-1">
       <div class="px-5 space-y-5">
         {#each groups.entries() as [category, examples] (category.id)}
@@ -70,4 +71,5 @@ const groups = $derived.by(() => {
       </div>
     </div>
   </div>
+  {/snippet}
 </NavPage>

--- a/packages/frontend/src/lib/images/ImageEmptyScreen.svelte
+++ b/packages/frontend/src/lib/images/ImageEmptyScreen.svelte
@@ -7,7 +7,7 @@ import BootcImageIcon from '../BootcImageIcon.svelte';
 <EmptyScreen
   icon={BootcImageIcon}
   title="No bootable container images">
-  <div slot="upperContent">
+  {#snippet upperContent()}
     <FirstImageScreen/>
-  </div>
+  {/snippet}
 </EmptyScreen>

--- a/packages/frontend/src/lib/images/ImagesList.svelte
+++ b/packages/frontend/src/lib/images/ImagesList.svelte
@@ -76,7 +76,7 @@ async function deleteSelectedImages(): Promise<void> {
 }
 
 let selectedItemsNumber = $state<number>(0);
-let table: Table;
+let table: Table<ImageInfoUI>;
 
 let statusColumn = new TableColumn<ImageInfoUI>('Status', {
   align: 'center',
@@ -120,19 +120,19 @@ const row = new TableRow<ImageInfoUI>({
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title="images">
-
-  <svelte:fragment slot="bottom-additional-actions">
+  {#snippet bottomAdditionalActions()}
     {#if selectedItemsNumber > 0}
      <Button
         on:click={deleteSelectedImages}
         title="Delete {selectedItemsNumber} selected items"
-        bind:inProgress={bulkDeleteInProgress}
+        inProgress={bulkDeleteInProgress}
         icon={faTrash} />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
-  </svelte:fragment>
+  {/snippet}
 
-  <div class="flex min-w-full h-full" slot="content">
+  {#snippet content()}
+  <div class="flex min-w-full h-full">
     <Table
       kind="image"
       bind:this={table}
@@ -151,4 +151,5 @@ const row = new TableRow<ImageInfoUI>({
       {/if}
     {/if}
   </div>
+  {/snippet}
 </NavPage>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,8 +221,8 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       '@podman-desktop/ui-svelte':
-        specifier: 1.18.0-202503071223-ce53e6c5bd4
-        version: 1.18.0-202503071223-ce53e6c5bd4(svelte-fa@4.0.4(svelte@5.39.6))(svelte@5.39.6)
+        specifier: 1.21.0
+        version: 1.21.0(svelte-fa@4.0.4(svelte@5.39.6))(svelte@5.39.6)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.1
         version: 6.2.1(svelte@5.39.6)(vite@7.1.7(@types/node@22.18.6)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
@@ -797,40 +797,20 @@ packages:
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@fortawesome/fontawesome-common-types@6.7.2':
-    resolution: {integrity: sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==}
-    engines: {node: '>=6'}
-
   '@fortawesome/fontawesome-common-types@7.0.1':
     resolution: {integrity: sha512-0VpNtO5cNe1/HQWMkl4OdncYK/mv9hnBte0Ew0n6DMzmo3Q3WzDFABHm6LeNTipt5zAyhQ6Ugjiu8aLaEjh1gg==}
-    engines: {node: '>=6'}
-
-  '@fortawesome/fontawesome-free@6.7.2':
-    resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
     engines: {node: '>=6'}
 
   '@fortawesome/fontawesome-free@7.0.1':
     resolution: {integrity: sha512-RLmb9U6H2rJDnGxEqXxzy7ANPrQz7WK2/eTjdZqyU9uRU5W+FkAec9uU5gTYzFBH7aoXIw2WTJSCJR4KPlReQw==}
     engines: {node: '>=6'}
 
-  '@fortawesome/free-brands-svg-icons@6.7.2':
-    resolution: {integrity: sha512-zu0evbcRTgjKfrr77/2XX+bU+kuGfjm0LbajJHVIgBWNIDzrhpRxiCPNT8DW5AdmSsq7Mcf9D1bH0aSeSUSM+Q==}
-    engines: {node: '>=6'}
-
   '@fortawesome/free-brands-svg-icons@7.0.1':
     resolution: {integrity: sha512-6xPmn5SrND/GM0+W33E77x05+aDn6RpR02eWd8eLdN0IxY0vXa5yU/ugaAKloOVxiG9w2330TSRsbJYL6c57Ow==}
     engines: {node: '>=6'}
 
-  '@fortawesome/free-regular-svg-icons@6.7.2':
-    resolution: {integrity: sha512-7Z/ur0gvCMW8G93dXIQOkQqHo2M5HLhYrRVC0//fakJXxcF1VmMPsxnG6Ee8qEylA8b8Q3peQXWMNZ62lYF28g==}
-    engines: {node: '>=6'}
-
   '@fortawesome/free-regular-svg-icons@7.0.1':
     resolution: {integrity: sha512-4V9fHbHjcx9Qu4O99AM5B4zuEDfB4zajk1I77hEzOxPN00f8g3484Aeq6WpfFcmookvjLE3Pr71Dhf/lqw7tbA==}
-    engines: {node: '>=6'}
-
-  '@fortawesome/free-solid-svg-icons@6.7.2':
-    resolution: {integrity: sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==}
     engines: {node: '>=6'}
 
   '@fortawesome/free-solid-svg-icons@7.0.1':
@@ -916,8 +896,8 @@ packages:
   '@podman-desktop/tests-playwright@1.21.0':
     resolution: {integrity: sha512-gMZSYD8QV5VDdDhgDIkZWehHF+FDYErEF5cAFBt86+WbHQUIZZz6EK06o20R9VdARDbRfv26DGmPksTqRn0N8g==}
 
-  '@podman-desktop/ui-svelte@1.18.0-202503071223-ce53e6c5bd4':
-    resolution: {integrity: sha512-iXPyknOYiQyRFureR8dVkeR2nmJt69KdiCfasipL5J0LCYlpdyF5MLRFvtCbS/OcJXJIgtiw2sQLx+k8kliyDQ==}
+  '@podman-desktop/ui-svelte@1.21.0':
+    resolution: {integrity: sha512-5ptTIAflI191jgF5q0n4YHxCo588OC4eUEAJhgUz01EglCIRSCUluI7WzQ8ML7X90iLbcJ5O8gsbXj6eERdbkg==}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0
       svelte-fa: ^4.0.0
@@ -4312,33 +4292,17 @@ snapshots:
       '@eslint/core': 0.15.2
       levn: 0.4.1
 
-  '@fortawesome/fontawesome-common-types@6.7.2': {}
-
   '@fortawesome/fontawesome-common-types@7.0.1': {}
 
-  '@fortawesome/fontawesome-free@6.7.2': {}
-
   '@fortawesome/fontawesome-free@7.0.1': {}
-
-  '@fortawesome/free-brands-svg-icons@6.7.2':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 6.7.2
 
   '@fortawesome/free-brands-svg-icons@7.0.1':
     dependencies:
       '@fortawesome/fontawesome-common-types': 7.0.1
 
-  '@fortawesome/free-regular-svg-icons@6.7.2':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 6.7.2
-
   '@fortawesome/free-regular-svg-icons@7.0.1':
     dependencies:
       '@fortawesome/fontawesome-common-types': 7.0.1
-
-  '@fortawesome/free-solid-svg-icons@6.7.2':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 6.7.2
 
   '@fortawesome/free-solid-svg-icons@7.0.1':
     dependencies:
@@ -4424,12 +4388,12 @@ snapshots:
 
   '@podman-desktop/tests-playwright@1.21.0': {}
 
-  '@podman-desktop/ui-svelte@1.18.0-202503071223-ce53e6c5bd4(svelte-fa@4.0.4(svelte@5.39.6))(svelte@5.39.6)':
+  '@podman-desktop/ui-svelte@1.21.0(svelte-fa@4.0.4(svelte@5.39.6))(svelte@5.39.6)':
     dependencies:
-      '@fortawesome/fontawesome-free': 6.7.2
-      '@fortawesome/free-brands-svg-icons': 6.7.2
-      '@fortawesome/free-regular-svg-icons': 6.7.2
-      '@fortawesome/free-solid-svg-icons': 6.7.2
+      '@fortawesome/fontawesome-free': 7.0.1
+      '@fortawesome/free-brands-svg-icons': 7.0.1
+      '@fortawesome/free-regular-svg-icons': 7.0.1
+      '@fortawesome/free-solid-svg-icons': 7.0.1
       humanize-duration: 3.33.1
       moment: 2.30.1
       svelte: 5.39.6


### PR DESCRIPTION
### What does this PR do?

Moves to the 1.12 Podman Desktop Svelte UI library:
- Changed lots of slots to snippets.
- Updated typing for Table in DiskImageList.
- Removed unused breadcrumbTitle, and Link title.
- Removed one unnecessary bind in ImagesList.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Check main pages for functional/UI regressions.