### PR TITLE
chore: fix epic issue type and label

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,6 +1,6 @@
 name: Epic ⚡
 description: A high-level feature
-type: epic
+type: epic ⚡
 labels: [kind/epic ⚡]
 
 body:


### PR DESCRIPTION
### What does this PR do?

Adding `type: epic` to the issue template not only didn't work, the kind/epic label doesn't show up anymore either. I don't have access to the org settings but the epic type appears to include the emoji - assuming it was copied from the kind and this should fix it.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fix for part of #2051.

### How to test this PR?

Merge, confirm type and label work.