### PR TITLE
chore: improve robustness of DiskImagesList test

### DIFF
--- a/packages/frontend/src/lib/disk-image/DiskImagesList.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImagesList.spec.ts
@@ -115,7 +115,7 @@ test('Test clicking on delete button', async () => {
   });
 
   expect(bootcClient.deleteBuilds).toHaveBeenCalledWith(['name1']);
-});
+}, 10_000);
 
 test('Test clicking on build button', async () => {
   vi.mocked(bootcClient.listHistoryInfo).mockResolvedValue(mockHistoryInfo);

--- a/packages/frontend/vite.config.js
+++ b/packages/frontend/vite.config.js
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ export default defineConfig({
     exclude: [],
   },
   test: {
+    retry: 2,
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
### What does this PR do?

Test runs locally in under 1.5s, but during build takes 4s+ on Mac/Linux and recently started hitting 5s timeout on Windows. Not clear if dependencies have slowed things down, builds VMs are throttled, or what else caused this to suddenly and consistently happen.

Locally I can see this particular test has a vi.waitFor() waiting for the table to render that's not accepted the first time, and doesn't get called again for 1s. Part of this is vite multithreading and other test's UI, but haven't been able to narrow down any specific cause or slowdown related to this test.

The cheap solution is just to extend the timeout of this particular test, and allow retries in case tests like this are only bumping a timeout once.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #2073.

### How to test this PR?

`pnpm test` completes without errors, even on slower Windows env.