### PR TITLE
chore(docs): update the correct url for the dashboard

### DIFF
--- a/packages/frontend/src/lib/FirstImage.svelte
+++ b/packages/frontend/src/lib/FirstImage.svelte
@@ -11,6 +11,7 @@ let pullInProgress = $state(false);
 let displayDisclaimer = $state(false);
 
 const exampleImage = 'registry.gitlab.com/fedora/bootc/examples/httpd:latest';
+const exampleImageReadmeUrl = 'https://gitlab.com/fedora/bootc/examples/-/tree/main/httpd';
 
 async function gotoBuild(): Promise<void> {
   // Split the image name to get the image name and tag and go to build page
@@ -45,7 +46,7 @@ let imageExists = $derived($imageInfo?.some(image => image.RepoTags?.includes(ex
 <div class="flex flex-col">
   <p class="pb-1 max-w-xl text-[var(--pd-card-header-text)]">
     Create your first disk image by {imageExists ? 'building' : 'pulling'} the <Link
-      externalRef={`https://${exampleImage}`}>example container image</Link
+      externalRef={`${exampleImageReadmeUrl}`}>example container image</Link
     >:
   </p>
 


### PR DESCRIPTION
chore(docs): update the correct url for the dashboard

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

On clicking, this should actually take you to the readme URL rather than
the 404 page.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A, found during event.

### How to test this PR?

N/A, see markdown.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
