### PR TITLE
chore: remove kind issue labels from templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: Bug 🐞
 description: Report a bug report
 type: bug
-labels: [kind/bug 🐞]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,7 +1,6 @@
 name: Epic ⚡
 description: A high-level feature
 type: epic
-labels: [kind/epic ⚡]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,7 +1,6 @@
 name: Feature 💡
 description: A request, idea, or new functionality
 type: feature
-labels: [kind/feature 💡]
 
 body:
   - type: markdown


### PR DESCRIPTION
### What does this PR do?

The new issue type templates are working, and all issues in this repo have been switched to use the correct type in addition to the kind/* labels. Project boards and queries are being updated to use types.

It may take a week or two for everything to be fully switched over, but given the low volume of issues in this repo it's easier to just remove labels from the templates now and close out the tracking issue; if there are any new issues that still need a kind/* label we can easily set it by hand.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #2051.

### How to test this PR?

Merge and confirm labels no longer added.