### PR TITLE
Update to latest bib

### DIFF
--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -19,8 +19,8 @@
 // Image related
 export const bootcImageBuilder = 'bootc-image-builder';
 export const bootcImageBuilderCentos =
-  'quay.io/centos-bootc/bootc-image-builder:sha256-b5a27308b23384279184f0217339b781fa38c19132d05f8e39ce8bf8af2ae5ef';
+  'quay.io/centos-bootc/bootc-image-builder:sha256-c2d6830647c095e29c8cabd1ef6ae0e903e77675b953655428ac5cef147541a0';
 
-export const bootcImageBuilderRHEL9 = 'registry.redhat.io/rhel9/bootc-image-builder:9.6';
-export const bootcImageBuilderRHEL10 = 'registry.redhat.io/rhel10/bootc-image-builder:10.0';
+export const bootcImageBuilderRHEL9 = 'registry.redhat.io/rhel9/bootc-image-builder:9.7';
+export const bootcImageBuilderRHEL10 = 'registry.redhat.io/rhel10/bootc-image-builder:10.1';
 export const macadamName = 'bootc';


### PR DESCRIPTION
### What does this PR do?

Updating to latest bib images for all three builders. With this I have been able to build all disk image types for all builders on my M4 with two exceptions:
 - Centos bib consistently failed on Anaconda ISO for one image - but consistently worked fine on another.
 - Have not been able to build any Anaconda ISOs with RHEL 10.1 bib.

In both of these cases I've gone back and found identical issues with the previous Centos and RHEL 10.0 bibs, so it is unrelated, and either due to a problem on my machine or unchanged from before. ISO will be likely be updated via issue #2058 as well.

Update: Found updates for the container images I was using and everything now builds fine. This is just another case of backward compatibility missing for ISO, if you have problems rebuild or look for newer images.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #2099.

### How to test this PR?

Test building as many combinations of image builder (changed via Preferences) and disk image type as possible.