### PR TITLE
fix(ci): use RUN cp for node_modules in container build

### DIFF
--- a/build/Containerfile
+++ b/build/Containerfile
@@ -48,13 +48,14 @@ COPY README.md /opt/app-root/extension/
 # We require the macadam.js binaries and library, so we will manually copy this over to the container image.
 # we rely on `pnpm build` before creating the container image, so we can safely assume that the macadam.js binaries are already present in the node_modules directory
 # and can copy them over to the container image.
-COPY node_modules/@crc-org/macadam.js /opt/app-root/extension/node_modules/@crc-org/macadam.js
-# Copy over ssh2 and it's dependencies (run jq '.dependencies' node_modules/ssh2/package.json locally to see)
-COPY node_modules/ssh2 /opt/app-root/extension/node_modules/ssh2
-COPY node_modules/asn1 /opt/app-root/extension/node_modules/asn1
-COPY node_modules/bcrypt-pbkdf /opt/app-root/extension/node_modules/bcrypt-pbkdf
-COPY node_modules/safer-buffer /opt/app-root/extension/node_modules/safer-buffer
-COPY node_modules/tweetnacl /opt/app-root/extension/node_modules/tweetnacl
+# Copy over ssh2 and its dependencies (run jq '.dependencies' node_modules/ssh2/package.json locally to see)
+RUN mkdir -p /opt/app-root/extension/node_modules/@crc-org && \
+    cp -r node_modules/@crc-org/macadam.js /opt/app-root/extension/node_modules/@crc-org/macadam.js && \
+    cp -r node_modules/ssh2 /opt/app-root/extension/node_modules/ssh2 && \
+    cp -r node_modules/asn1 /opt/app-root/extension/node_modules/asn1 && \
+    cp -r node_modules/bcrypt-pbkdf /opt/app-root/extension/node_modules/bcrypt-pbkdf && \
+    cp -r node_modules/safer-buffer /opt/app-root/extension/node_modules/safer-buffer && \
+    cp -r node_modules/tweetnacl /opt/app-root/extension/node_modules/tweetnacl
 
 # Copy the extension to a new image
 FROM scratch


### PR DESCRIPTION
fix(ci): use RUN cp for node_modules in container build

### What does this PR do?

The container build runs `pnpm install` inside the builder container,
so node_modules exists there, not on the host anymore.

Changed COPY to `RUN cp -r` to copy from within the container, since we
are using `FROM ghcr.io/podman-desktop/extension-bootc-builder:next AS
builder` (the node_modules is going to be there..)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of #2101

### How to test this PR?

<!-- Please explain steps to reproduce -->

CI passes :)

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
