### PR TITLE
fix(ci): adds variables to output section, use github tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,10 @@ env:
 jobs:
   tag:
     runs-on: ubuntu-22.04
+    outputs:
+      githubTag: ${{ steps.TAG_UTIL.outputs.githubTag }}
+      bootcExtensionVersion: ${{ steps.TAG_UTIL.outputs.bootcExtensionVersion }}
+      releaseId: ${{ steps.create_release.outputs.id }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -167,6 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ needs.tag.outputs.githubTag }}
           fetch-depth: 0
 
       - name: Install qemu dependency


### PR DESCRIPTION
fix(ci): adds variables to output section, use github tag

### What does this PR do?

Added missing job outputs to the tag job (too expose githubTag,
bootcExtensionVersion, and releaseId)

Use the ref github tag output instead of HEAD (or else it will just
build the HEAD commit / may not be accurate).

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of #2101

### How to test this PR?

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
