### PR TITLE
chore(docs): fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ RUN echo "root:root" | chpasswd
 
 ## Advanced usage
 
-![](/docs/img/balena_etcher.png)
+![](https://raw.githubusercontent.com/podman-desktop/podman-desktop-extension-bootc/main/docs/img/balena_etcher.png)
 
 ### Booting the image
 


### PR DESCRIPTION
chore(docs): fix broken link

### What does this PR do?

When we display this in PD catalog, we must use raw links to display the
image. Currently this is not displayed.

Switches the image to use the raw link.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

N/A, image should be fine to the README :)

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
