### PR TITLE
chore: update ssh information to ed25519 keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,14 @@ RUN echo "root:root" | chpasswd
 
 > You can test the image locally on both macOS and Linux using the "Create VM" button on the "Disk Images" page. Windows support is upcoming.
 
+**SSH requirements:** The VM creation feature only supports **ed25519** SSH keys. Ensure you have an ed25519 key pair generated (default location: `~/.ssh/id_ed25519`). To generate one:
+
+```sh
+ssh-keygen -t ed25519
+```
+
+Your public key information (ex. `ssh-ed25519 AAABBBCCC...`) from `~/.ssh/id_ed25519.pub` must be added to your bootc image during the build process for SSH access to work.
+
 ![](https://raw.githubusercontent.com/podman-desktop/podman-desktop-extension-bootc/main/docs/img/vm.gif)
 
 ## Advanced usage

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -29,8 +29,8 @@
         "bootc.macadam.ssh.private.key": {
           "type": "string",
           "format": "file",
-          "default": "~/.ssh/id_rsa",
-          "description": "Default SSH private key for the Virtual Machine testing via Macadam (Default is ~/.ssh/id_rsa)"
+          "default": "~/.ssh/id_ed25519",
+          "description": "Default SSH private key for the Virtual Machine testing via Macadam (Default is ~/.ssh/id_ed25519)"
         },
         "bootc.builder": {
           "type": "string",

--- a/packages/backend/src/api-impl.spec.ts
+++ b/packages/backend/src/api-impl.spec.ts
@@ -125,7 +125,7 @@ test('createVM should call the extension api', async () => {
 
   const options = {
     imagePath: '~/foobar',
-    sshIdentityPath: '~/foobar/id_rsa',
+    sshIdentityPath: '~/foobar/id_ed25519',
     username: 'foobar',
   } as macadam.CreateVmOptions;
 

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -865,7 +865,7 @@ $: if (availableArchitectures) {
                       <Input
                         bind:value={user.key}
                         id="buildConfigKey.${index}"
-                        placeholder="SSH public key (ex. ssh-rsa AAABBBCCC...)"
+                        placeholder="SSH public key (ex. ssh-ed25519 AAABBBCCC...)"
                         aria-label="buildConfigKey.${index}"
                         class="mr-2" />
 

--- a/packages/frontend/src/CreateVM.svelte
+++ b/packages/frontend/src/CreateVM.svelte
@@ -206,7 +206,7 @@ async function createVM(): Promise<void> {
               aria-label="ssh-username" />
           </div>
           <div class="pb-4">
-            <label for="ssh-private-key" class="block mb-2 font-semibold">SSH private key filepath (ex. ~/.ssh/id_rsa)</label>
+            <label for="ssh-private-key" class="block mb-2 font-semibold">SSH private key filepath (ex. ~/.ssh/id_ed25519)</label>
             <div class="flex flex-row space-x-3">
               <Input
                 name="ssh-private-key"


### PR DESCRIPTION
chore: update ssh information to ed25519 keys

### What does this PR do?

In multiple locations we list `rsa` ssh key support. In reality, it's
`ed25519` keys which are only supported.

`ed25519` keys are wayy more modern / secure than `rsa` and is the
only "offical" keys supported with `macadam`.

This PR:
* Adds information to our README
* Removes references to rsa and replaced with ed25519 key information
* Replaces the default ~/.ssh/id_rsa location with ed25519

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

<img width="1017" height="122" alt="Screenshot 2025-12-19 at 4 22 53 PM" src="https://github.com/user-attachments/assets/fadd4552-4a02-4221-842a-5cee44c66260" />

<img width="910" height="116" alt="Screenshot 2025-12-19 at 4 23 09 PM" src="https://github.com/user-attachments/assets/99dda762-ba3c-4704-8029-a04f9adebaed" />


### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/extension-bootc/issues/2156

### How to test this PR?

<!-- Please explain steps to reproduce -->

See visual changes within bootc that it now references ed25519 keys
instead.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
