### PR TITLE
chore: update old references

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ This extension can be installed through the **Extensions** section of Podman Des
 A version of the extension using the latest commit changes can be installed via the **Install custom...** button with the following link:
 
 ```
-ghcr.io/containers/podman-desktop-extension-bootc:nightly
+ghcr.io/podman-desktop/extension-bootc:next
 ```
 
 ## Usage

--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -99,7 +99,7 @@ test.describe('BootC Extension', () => {
     test.setTimeout(200_000);
 
     const extensionsPage = await navigationBar.openExtensions();
-    await extensionsPage.installExtensionFromOCIImage('ghcr.io/podman-desktop/podman-desktop-extension-bootc:nightly');
+    await extensionsPage.installExtensionFromOCIImage('ghcr.io/podman-desktop/extension-bootc:next');
 
     await playExpect
       .poll(async () => await extensionsPage.extensionIsInstalled(extensionLabel), { timeout: 30_000 })


### PR DESCRIPTION
### What does this PR do?

When we switched to using a container build we started using a new image name (podman-desktop-extension-bootc -> extension-bootc) and tag ('nightly' -> 'next') to match other new extensions and be more consistent. This just fixes the last two references (and fixes an org name).

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #2181.

### How to test this PR?

Confirm image name in readme.