### PR TITLE
chore: update repo name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Workflow for developing:
 pnpm watch
 
 # In a separate terminal in the Podman Desktop folder:
-pnpm watch --extension-folder ../podman-desktop-extension-bootc/packages/backend
+pnpm watch --extension-folder ../extension-bootc/packages/backend
 ```
 
 Workflow for testing and validation checking before PR submission:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BootC (Bootable Container) Extension for Podman Desktop
 
-![](https://raw.githubusercontent.com/podman-desktop/podman-desktop-extension-bootc/main/docs/img/banner.png)
+![](https://raw.githubusercontent.com/podman-desktop/extension-bootc/main/docs/img/banner.png)
 
 Want to create a bootable operating system from a Containerfile? Download this extension!
 
@@ -85,7 +85,7 @@ All of our maintained example images are on the [gitlab.com/fedora/bootc/example
 
 You can also pull our example image based on the [`httpd`](https://gitlab.com/bootc-org/examples/-/tree/main/httpd) example:
 
-![](https://raw.githubusercontent.com/podman-desktop/podman-desktop-extension-bootc/main/docs/img/clicking_pull.gif)
+![](https://raw.githubusercontent.com/podman-desktop/extension-bootc/main/docs/img/clicking_pull.gif)
 
 ## Use Case
 
@@ -133,7 +133,7 @@ podman machine start
 
 Or set when initially creating a Podman Machine via Podman Desktop:
 
-![rootful setup](https://raw.githubusercontent.com/podman-desktop/podman-desktop-extension-bootc/main/docs/img/rootful_setup.png)
+![rootful setup](https://raw.githubusercontent.com/podman-desktop/extension-bootc/main/docs/img/rootful_setup.png)
 
 ### Escalated Privileges (Linux)
 
@@ -151,7 +151,7 @@ This extension can be installed through the **Extensions** section of Podman Des
 2. Click on the **Catalog** tab.
 3. Install the extension.
 
-![](https://raw.githubusercontent.com/podman-desktop/podman-desktop-extension-bootc/main/docs/img/catalog_install.gif)
+![](https://raw.githubusercontent.com/podman-desktop/extension-bootc/main/docs/img/catalog_install.gif)
 
 ### Nightly version
 
@@ -175,13 +175,13 @@ FROM quay.io/centos-bootc/centos-bootc:stream10
 RUN echo "root:root" | chpasswd
 ```
 
-![](https://raw.githubusercontent.com/podman-desktop/podman-desktop-extension-bootc/main/docs/img/build_image.gif)
+![](https://raw.githubusercontent.com/podman-desktop/extension-bootc/main/docs/img/build_image.gif)
 
 2. **Build the disk image:**
 
 > Build the disk image, this takes approximately 2-5 minutes depending on the performance of your machine.
 
-![](https://raw.githubusercontent.com/podman-desktop/podman-desktop-extension-bootc/main/docs/img/bootc_building.gif)
+![](https://raw.githubusercontent.com/podman-desktop/extension-bootc/main/docs/img/bootc_building.gif)
 
 3. **Testing the image locally (macOS and Linux):**
 
@@ -195,11 +195,11 @@ ssh-keygen -t ed25519
 
 Your public key information (ex. `ssh-ed25519 AAABBBCCC...`) from `~/.ssh/id_ed25519.pub` must be added to your bootc image during the build process for SSH access to work.
 
-![](https://raw.githubusercontent.com/podman-desktop/podman-desktop-extension-bootc/main/docs/img/vm.gif)
+![](https://raw.githubusercontent.com/podman-desktop/extension-bootc/main/docs/img/vm.gif)
 
 ## Advanced usage
 
-![](https://raw.githubusercontent.com/podman-desktop/podman-desktop-extension-bootc/main/docs/img/balena_etcher.png)
+![](https://raw.githubusercontent.com/podman-desktop/extension-bootc/main/docs/img/balena_etcher.png)
 
 ### Booting the image
 
@@ -226,7 +226,7 @@ See [bootc-dev.github.io/bootc](https://bootc-dev.github.io/bootc) for more info
 
 Preferences such as the default `bootc-builder-image` as well as timeouts can be adjusted within the **Preferences** section of Podman Desktop.
 
-![](https://raw.githubusercontent.com/podman-desktop/podman-desktop-extension-bootc/main/docs/img/preferences.png)
+![](https://raw.githubusercontent.com/podman-desktop/extension-bootc/main/docs/img/preferences.png)
 
 ## Offline / airplane mode
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,19 +10,19 @@ In the below example, we will pretend that we're upgrading from `1.1.0` to `1.2.
 
 ## Releasing on GitHub
 
-1. Go to https://github.com/podman-desktop/podman-desktop-extension-bootc/actions/workflows/release.yaml.
+1. Go to https://github.com/podman-desktop/extension-bootc/actions/workflows/release.yaml.
 1. Click on the top right drop-down menu `Run workflow`.
 1. Enter the name of the release. Example: `1.2.0` (DO NOT use the v prefix like v1.2.0)
 1. Specify the branch to use for the new release. It's main for all major releases. For a bugfix release, you'll select a different branch.
 1. Click on the `Run workflow` button.
 1. Note: `Run workflow` takes approximately 20-30 minutes since we build and install the dependencies from scratch, go grab a coffee!
-1. Make sure that all tasks for the respective release milestone are completed / updated, then close it. https://github.com/podman-desktop/podman-desktop-extension-bootc/milestones
+1. Make sure that all tasks for the respective release milestone are completed / updated, then close it. https://github.com/podman-desktop/extension-bootc/milestones
 1. If not already created, click on `New Milestone` and create a new milestone for the NEXT release.
-1. Check that https://github.com/podman-desktop/podman-desktop-extension-bootc/actions/workflows/release.yaml has been completed.
+1. Check that https://github.com/podman-desktop/extension-bootc/actions/workflows/release.yaml has been completed.
 1. Ensure the image has been successfully published to https://github.com/podman-desktop/extension-bootc/pkgs/container/extension-bootc
 1. There should be an automated PR that has been created. The title looks like `chore: 📢 Bump version to 1.3.0`. Rerun workflow manually if some of e2e tests are failing.
 1. Wait for the PR above to be approved and merged before continuing with the steps.
-1. Edit the new release https://github.com/podman-desktop/podman-desktop-extension-bootc/releases/edit/v1.2.0.
+1. Edit the new release https://github.com/podman-desktop/extension-bootc/releases/edit/v1.2.0.
 1. Select previous tag (v1.1.0) and click on `Generate release notes` and then click on `Update release`.
 
 ## Release testing


### PR DESCRIPTION
### What does this PR do?

While fixing #2181 I found several references to the original repo name, updating those for consistency and to avoid future breakage.

Note: PR check and e2e build still use podman-desktop-extension-bootc as a folder name, but that's not directly related.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related to #2181.

### How to test this PR?

Check paths are correct.