### PR TITLE
chore: update macadam

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -129,7 +129,7 @@
     "vitest": "^4.0.10"
   },
   "dependencies": {
-    "@crc-org/macadam.js": "0.2.0-202601061512-0729168",
+    "@crc-org/macadam.js": "0.4.0-next.202601130801-a74070c",
     "semver": "^7.7.3",
     "compare-versions": "^6.1.1",
     "ssh2": "^1.16.0"

--- a/packages/backend/src/extension.spec.ts
+++ b/packages/backend/src/extension.spec.ts
@@ -130,7 +130,7 @@ describe('test ensureMacadamInitialized doesnt double init', () => {
   test('should propagate init error when lazy initializing via getJSONMachineListByProvider', async () => {
     vi.mocked(podmanDesktopApi.env).isMac = true;
     vi.mocked(podmanDesktopApi.env).isWindows = false;
-    mocks.areBinariesAvailableMock.mockReturnValue(false);
+    mocks.areBinariesAvailableMock.mockResolvedValue(false);
     mocks.macadamInitMock.mockRejectedValue(new Error('Init failed'));
 
     await activate(fakeContext);
@@ -143,7 +143,7 @@ describe('test ensureMacadamInitialized doesnt double init', () => {
   test('should lazily initialize macadam when listing VMs and binary was not installed at activation', async () => {
     vi.mocked(podmanDesktopApi.env).isMac = true;
     vi.mocked(podmanDesktopApi.env).isWindows = false;
-    mocks.areBinariesAvailableMock.mockReturnValue(false);
+    mocks.areBinariesAvailableMock.mockResolvedValue(false);
     mocks.macadamInitMock.mockResolvedValue(undefined);
     mocks.macadamListVmsMock.mockResolvedValue([]);
 
@@ -162,7 +162,7 @@ describe('test ensureMacadamInitialized doesnt double init', () => {
   test('should not re-initialize macadam if already initialized', async () => {
     vi.mocked(podmanDesktopApi.env).isMac = true;
     vi.mocked(podmanDesktopApi.env).isWindows = false;
-    mocks.areBinariesAvailableMock.mockReturnValue(true);
+    mocks.areBinariesAvailableMock.mockResolvedValue(true);
     mocks.macadamInitMock.mockResolvedValue(undefined);
     mocks.macadamListVmsMock.mockResolvedValue([]);
 
@@ -273,7 +273,7 @@ describe('lazy macadam initialization', () => {
   test('macOs: should NOT initialize macadam on activate when binary does not exist', async () => {
     vi.mocked(podmanDesktopApi.env).isMac = true;
     vi.mocked(podmanDesktopApi.env).isWindows = false;
-    mocks.areBinariesAvailableMock.mockReturnValue(false);
+    mocks.areBinariesAvailableMock.mockResolvedValue(false);
 
     await activate(fakeContext);
 
@@ -283,7 +283,7 @@ describe('lazy macadam initialization', () => {
   test('macOS: should initialize macadam on activate when binary exists', async () => {
     vi.mocked(podmanDesktopApi.env).isMac = true;
     vi.mocked(podmanDesktopApi.env).isWindows = false;
-    mocks.areBinariesAvailableMock.mockReturnValue(true);
+    mocks.areBinariesAvailableMock.mockResolvedValue(true);
     mocks.macadamInitMock.mockResolvedValue(undefined);
 
     await activate(fakeContext);
@@ -295,7 +295,7 @@ describe('lazy macadam initialization', () => {
     vi.mocked(podmanDesktopApi.env).isMac = false;
     vi.mocked(podmanDesktopApi.env).isWindows = false;
     vi.mocked(podmanDesktopApi.env).isLinux = true;
-    mocks.areBinariesAvailableMock.mockReturnValue(false);
+    mocks.areBinariesAvailableMock.mockResolvedValue(false);
 
     await activate(fakeContext);
 
@@ -306,7 +306,7 @@ describe('lazy macadam initialization', () => {
     vi.mocked(podmanDesktopApi.env).isMac = false;
     vi.mocked(podmanDesktopApi.env).isWindows = false;
     vi.mocked(podmanDesktopApi.env).isLinux = true;
-    mocks.areBinariesAvailableMock.mockReturnValue(true);
+    mocks.areBinariesAvailableMock.mockResolvedValue(true);
     mocks.macadamInitMock.mockResolvedValue(undefined);
 
     await activate(fakeContext);
@@ -327,7 +327,7 @@ describe('lazy macadam initialization', () => {
   test('mac: should handle macadam init error gracefully during activate', async () => {
     vi.mocked(podmanDesktopApi.env).isMac = true;
     vi.mocked(podmanDesktopApi.env).isWindows = false;
-    mocks.areBinariesAvailableMock.mockReturnValue(true);
+    mocks.areBinariesAvailableMock.mockResolvedValue(true);
     mocks.macadamInitMock.mockRejectedValue(new Error('Init failed'));
 
     await activate(fakeContext);

--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -198,7 +198,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     // Only initialize and start monitoring if macadam binary is already installed.
     // This avoids prompting for sudo on extension activation (macOS).
     // If not installed, init() will be called lazily when user performs a VM operation.
-    if (macadam.areBinariesAvailable()) {
+    if (await macadam.areBinariesAvailable()) {
       try {
         await macadam.init();
         macadamInitialized = true;

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -17,7 +17,7 @@
     "watch": "vite --mode development build -w"
   },
   "dependencies": {
-    "@crc-org/macadam.js": "0.2.0-202601061512-0729168",
+    "@crc-org/macadam.js": "0.4.0-next.202601130801-a74070c",
     "svelte-check": "^4.3.5",
     "svelte-preprocess": "^6.0.3",
     "tinro": "^0.6.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,8 +117,8 @@ importers:
   packages/backend:
     dependencies:
       '@crc-org/macadam.js':
-        specifier: 0.2.0-202601061512-0729168
-        version: 0.2.0-202601061512-0729168
+        specifier: 0.4.0-next.202601130801-a74070c
+        version: 0.4.0-next.202601130801-a74070c
       compare-versions:
         specifier: ^6.1.1
         version: 6.1.1
@@ -193,8 +193,8 @@ importers:
   packages/frontend:
     dependencies:
       '@crc-org/macadam.js':
-        specifier: 0.2.0-202601061512-0729168
-        version: 0.2.0-202601061512-0729168
+        specifier: 0.4.0-next.202601130801-a74070c
+        version: 0.4.0-next.202601130801-a74070c
       svelte-check:
         specifier: ^4.3.5
         version: 4.3.5(picomatch@4.0.3)(svelte@5.46.1)(typescript@5.9.3)
@@ -561,8 +561,8 @@ packages:
     resolution: {integrity: sha512-VmIFV/JkBRhDRRv7N5B7zEUkNZIx9Mp+8Pe65erz0rKycXLsi8Epcw0XJ+btSeRXgTzE7DyOyA9bkJ9mn/yqVQ==}
     engines: {node: '>=v18'}
 
-  '@crc-org/macadam.js@0.2.0-202601061512-0729168':
-    resolution: {integrity: sha512-ZXAip1GakSDuCm4wOMyloLrPGquGxls4G1TWB8TOgHNa/jZMNK0SjyGhgKHuWoyvvpi6d39Jrmsv9xA2DaMpHw==}
+  '@crc-org/macadam.js@0.4.0-next.202601130801-a74070c':
+    resolution: {integrity: sha512-YNDUMP3NRAlhWdtYFav2czBgAu1iBXiATbw1/jS9H4u+QWXGlFwS5qKHQO5qdYS1481G/a0X7377WX+2+Wd+QA==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -4088,9 +4088,10 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.2
       chalk: 5.6.2
 
-  '@crc-org/macadam.js@0.2.0-202601061512-0729168':
+  '@crc-org/macadam.js@0.4.0-next.202601130801-a74070c':
     dependencies:
       '@podman-desktop/api': 1.24.2
+      semver: 7.7.3
 
   '@csstools/color-helpers@5.1.0': {}
 


### PR DESCRIPTION
### What does this PR do?

Update macadam to the latest to allow upgrading macadam binaries on macOS.

Same change as https://github.com/redhat-developer/podman-desktop-rhel-ext/pull/420

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #2211.

### How to test this PR?

Existing PR checks updated.