### PR TITLE
chore: update to macadam 0.5

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -129,7 +129,7 @@
     "vitest": "^4.0.10"
   },
   "dependencies": {
-    "@crc-org/macadam.js": "0.4.0-next.202601130801-a74070c",
+    "@crc-org/macadam.js": "0.5.0",
     "semver": "^7.7.3",
     "compare-versions": "^6.1.1",
     "ssh2": "^1.16.0"

--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -198,7 +198,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
     // Only initialize and start monitoring if macadam binary is already installed.
     // This avoids prompting for sudo on extension activation (macOS).
     // If not installed, init() will be called lazily when user performs a VM operation.
-    if (await macadam.areBinariesAvailable()) {
+    if (macadam.areBinariesAvailable()) {
       try {
         await macadam.init();
         macadamInitialized = true;
@@ -258,6 +258,8 @@ export async function getConfigurationValue<T>(property: string): Promise<T | un
 // rather than prompting on extension activation.
 // Exported so MacadamHandler can trigger monitoring after VM creation.
 export async function ensureMacadamInitialized(): Promise<void> {
+  await macadam.ensureBinariesUpToDate();
+
   if (macadamInitialized) {
     return;
   }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -17,7 +17,7 @@
     "watch": "vite --mode development build -w"
   },
   "dependencies": {
-    "@crc-org/macadam.js": "0.4.0-next.202601130801-a74070c",
+    "@crc-org/macadam.js": "0.5.0",
     "svelte-check": "^4.3.5",
     "svelte-preprocess": "^6.0.3",
     "tinro": "^0.6.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,8 +117,8 @@ importers:
   packages/backend:
     dependencies:
       '@crc-org/macadam.js':
-        specifier: 0.4.0-next.202601130801-a74070c
-        version: 0.4.0-next.202601130801-a74070c
+        specifier: 0.5.0
+        version: 0.5.0
       compare-versions:
         specifier: ^6.1.1
         version: 6.1.1
@@ -193,8 +193,8 @@ importers:
   packages/frontend:
     dependencies:
       '@crc-org/macadam.js':
-        specifier: 0.4.0-next.202601130801-a74070c
-        version: 0.4.0-next.202601130801-a74070c
+        specifier: 0.5.0
+        version: 0.5.0
       svelte-check:
         specifier: ^4.3.5
         version: 4.3.5(picomatch@4.0.3)(svelte@5.46.4)(typescript@5.9.3)
@@ -561,8 +561,8 @@ packages:
     resolution: {integrity: sha512-VmIFV/JkBRhDRRv7N5B7zEUkNZIx9Mp+8Pe65erz0rKycXLsi8Epcw0XJ+btSeRXgTzE7DyOyA9bkJ9mn/yqVQ==}
     engines: {node: '>=v18'}
 
-  '@crc-org/macadam.js@0.4.0-next.202601130801-a74070c':
-    resolution: {integrity: sha512-YNDUMP3NRAlhWdtYFav2czBgAu1iBXiATbw1/jS9H4u+QWXGlFwS5qKHQO5qdYS1481G/a0X7377WX+2+Wd+QA==}
+  '@crc-org/macadam.js@0.5.0':
+    resolution: {integrity: sha512-WBnReMQDkDJskNktER63+OYTBfWjdvT6+ZVUKdqRbUZrFqHjUPjtyEdrdc0yUV5JsqtUyQMMRuKhisiODO3x/g==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -4088,7 +4088,7 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.2
       chalk: 5.6.2
 
-  '@crc-org/macadam.js@0.4.0-next.202601130801-a74070c':
+  '@crc-org/macadam.js@0.5.0':
     dependencies:
       '@podman-desktop/api': 1.24.2
       semver: 7.7.3


### PR DESCRIPTION
### What does this PR do?

Moves up to macadam 0.5, which reverts macadam.areBinariesAvailable() back to boolean from Promise<boolean>.

It adds ensureBinariesUpToDate() for installing or upgrading the binaries. This is now called from ensureMacadamInitialized(), which is not called on startup but should be called whenever the user interacts with macadam directly.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #2229.

### How to test this PR?

Confirm macadam install or update isn't triggered on startup of the bootc extension, but is when you use macadam features (e.g. start a VM).