### PR TITLE
fix(ci): add chown 1001:0 settings when copying

### DIFF
--- a/build/Containerfile.builder
+++ b/build/Containerfile.builder
@@ -23,9 +23,9 @@ ENV HOME=/opt/app-root
 # copy the application files to the /opt/app-root/extension-source directory
 WORKDIR /opt/app-root/extension-source
 RUN mkdir -p /opt/app-root/extension-source
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc /opt/app-root/extension-source/
-COPY packages/backend/package.json /opt/app-root/extension-source/packages/backend/package.json
-COPY packages/frontend/package.json /opt/app-root/extension-source/packages/frontend/package.json
+COPY --chown=1001:0 package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc /opt/app-root/extension-source/
+COPY --chown=1001:0 packages/backend/package.json /opt/app-root/extension-source/packages/backend/package.json
+COPY --chown=1001:0 packages/frontend/package.json /opt/app-root/extension-source/packages/frontend/package.json
 
 RUN npm install --global pnpm@10 && \
     pnpm --frozen-lockfile install


### PR DESCRIPTION
fix(ci): add chown 1001:0 settings when copying

### What does this PR do?

The ubi8 image uses non-root by default.

Make sure that the files are non-root so that pnpm is able to create the
correct directories (ex. node_modules).

This fixes the currently failing release CI.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

N/A, discovered while doing the release.

### How to test this PR?

Build it locally:

```sh
~/s/d/e/podman-desktop-extension-bootc (main|✚1) $ podman build -f build/Containerfile.builder -t extension
-bootc-builder:latest .
STEP 1/8: FROM registry.access.redhat.com/ubi10/nodejs-24-minimal:10.1-1766060610
Trying to pull registry.access.redhat.com/ubi10/nodejs-24-minimal:10.1-1766060610...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:f416e7c13e96a1bec342af3e79184aaf45de55dd66939245eb76ca02465c54c7
Copying blob sha256:1f4e519f27f193775852ceb9039d036443f701eb8f093b8c4a81ab3575b50739
Copying config sha256:0859f7f04dd3180ee1c26782c639f428d20174bd645d045c6c92f1c746b0fa39
Writing manifest to image destination
Storing signatures
STEP 2/8: ENV HOME=/opt/app-root
--> ff8224be9f62
STEP 3/8: WORKDIR /opt/app-root/extension-source
--> 69daaa410971
STEP 4/8: RUN mkdir -p /opt/app-root/extension-source
--> 477bda9213cf
STEP 5/8: COPY --chown=1001:0 package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc /opt/app-root/extension-source/
--> 58e6218e86e7
STEP 6/8: COPY --chown=1001:0 packages/backend/package.json /opt/app-root/extension-source/packages/backend/package.json
--> b9d7813fe81b
STEP 7/8: COPY --chown=1001:0 packages/frontend/package.json /opt/app-root/extension-source/packages/frontend/package.json
--> 48dc9a690017
STEP 8/8: RUN npm install --global pnpm@10 &&     pnpm --frozen-lockfile install

added 1 package in 1s

1 package is looking for funding
  run `npm fund` for details
Scope: all 3 workspace projects
Lockfile is up to date, resolution step is skipped
Packages: +686
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 0, reused 0, downloaded 1, added 0
Progress: resolved 0, reused 0, downloaded 127, added 116
Progress: resolved 0, reused 0, downloaded 251, added 243
Progress: resolved 0, reused 0, downloaded 383, added 346
Progress: resolved 0, reused 0, downloaded 541, added 504
Progress: resolved 0, reused 0, downloaded 667, added 684
Progress: resolved 0, reused 0, downloaded 668, added 685
Progress: resolved 0, reused 0, downloaded 669, added 685
Progress: resolved 0, reused 0, downloaded 669, added 686, done

. prepare$ husky install
. prepare: husky - install command is DEPRECATED
. prepare: .git can't be found
. prepare: Done
Done in 10.6s using pnpm v10.15.0
COMMIT extension-bootc-builder:latest
--> 70850d53eef9
Successfully tagged localhost/extension-bootc-builder:latest
70850d53eef95b6b8d4993d15a86aef71f9ef4b57bd650b9dd41fe8abeb2d457
```

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
