### PR TITLE
chore(macadam): only update on vm actions

### DIFF
--- a/packages/backend/src/macadam.ts
+++ b/packages/backend/src/macadam.ts
@@ -70,7 +70,7 @@ export class MacadamHandler {
           // Trigger the extension.ts monitoring loop now that macadam is initialized
           // and a VM has been created. This ensures the new VM appears in the Resources list after creation.
           // Creating a VM is the area where macadam is first initialized and the "install macadam" sudo prompt pops up.
-          await ensureMacadamInitialized();
+          await ensureMacadamInitialized(true);
         },
       )
       .catch((e: unknown) => {


### PR DESCRIPTION
chore(macadam): only update on vm actions

### What does this PR do?

On initialization, if the user has an older version of macadam
installed, but installs the bootc extension (from custom or the
catalog), they will get the "sudo prompt" install immediately.

Having an older version installed on initialization is fine as the only
function that bootc uses is the "json machine list" to get the list of
VMs.

Instead, we will prompt the user to update the macadam binary if they
have an old one installed, and we go to use a VM action.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Have an old macadam binary installed to `/opt/macadam/bin/macadam`

2. Have NO BOOTC INSTALLED on PD

3. Install Custom... and use an image of this container

4. No more prompt when installing.

5. Go to bootc extension

6. Go to Disk Images > Create VM

7. Should now get prompt

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
