### PR TITLE
chore: revert minimum PD version

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,7 +7,7 @@
   "publisher": "redhat",
   "license": "Apache-2.0",
   "engines": {
-    "podman-desktop": ">=1.25.0"
+    "podman-desktop": ">=1.18.0"
   },
   "main": "./dist/extension.js",
   "contributes": {


### PR DESCRIPTION
### What does this PR do?

Due to https://github.com/podman-desktop/podman-desktop/issues/15767, older Podman Desktop versions will show the latest bootc extension in the catalog. If the user install, it fails on startup due to our version check in activate(). The latest extension version currently needs to be compatible with all past versions of Podman Desktop.

This reverts the minimum PD version back to 1.18 for now, so that the extension won't fail on startup.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Half of #2241, also needs to be fixed on 1.12 branch.

### How to test this PR?

Revert Podman Desktop back to 1.24 or prior. The bootc extension from main will fail to activate(), but will after this change.