### PR TITLE
chore: remove startup version check

### DIFF
--- a/packages/backend/src/extension.spec.ts
+++ b/packages/backend/src/extension.spec.ts
@@ -188,62 +188,6 @@ test('check activate', async () => {
   expect(mocks.logUsageMock).toHaveBeenCalled();
 });
 
-describe('version checker', () => {
-  test('incompatible version', async () => {
-    (podmanDesktopApi.version as string) = '0.7.0';
-    await expect(async () => {
-      await activate(fakeContext);
-    }).rejects.toThrowError('Extension is not compatible with Podman Desktop version below 1.0.0 (Current 0.7.0).');
-
-    // expect the error to be logged
-    expect(mocks.logErrorMock).toBeCalledWith('start.incompatible', {
-      version: '0.7.0',
-      message: 'error activating extension on version below 1.0.0',
-    });
-  });
-
-  test('next version', async () => {
-    (podmanDesktopApi.version as string) = '1.0.1-next';
-    await activate(fakeContext);
-
-    expect(mocks.logErrorMock).not.toHaveBeenCalled();
-  });
-
-  /**
-   * This check ensure we do not support old nighties version to be used
-   * update introduced in https://github.com/podman-desktop/podman-desktop/pull/7643
-   */
-  test('old nightlies version', async () => {
-    (podmanDesktopApi.version as string) = 'v0.0.202404030805-3cb4544';
-    await expect(async () => {
-      await activate(fakeContext);
-    }).rejects.toThrowError(
-      'Extension is not compatible with Podman Desktop version below 1.0.0 (Current v0.0.202404030805-3cb4544).',
-    );
-
-    expect(mocks.logErrorMock).toHaveBeenCalled();
-  });
-
-  test('new version nighties', async () => {
-    (podmanDesktopApi.version as string) = `1.0.0-${Date.now()}-b35e7bef`;
-
-    expect(mocks.logErrorMock).not.toHaveBeenCalled();
-  });
-
-  test('invalid version', async () => {
-    (podmanDesktopApi.version as string | undefined) = undefined;
-    await expect(async () => {
-      await activate(fakeContext);
-    }).rejects.toThrowError('Extension is not compatible with Podman Desktop version below 1.0.0 (Current unknown).');
-
-    // expect the activate method to be called on the studio class
-    expect(mocks.logErrorMock).toBeCalledWith('start.incompatible', {
-      version: 'unknown',
-      message: 'error activating extension on version below 1.0.0',
-    });
-  });
-});
-
 test('check deactivate', async () => {
   await deactivate();
 

--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,6 @@ import { RpcExtension } from '/@shared/src/messages/MessageProxy';
 import { BootcApiImpl } from './api-impl';
 import { HistoryNotifier } from './history/historyNotifier';
 import { Messages } from '/@shared/src/messages/Messages';
-import { satisfies, minVersion, coerce } from 'semver';
-import { engines } from '../package.json';
 import * as macadamJSPackage from '@crc-org/macadam.js';
 import { isHyperVEnabled, isWSLEnabled } from './macadam/win/utils';
 import { getErrorMessage, verifyContainerProivder } from './macadam/utils';
@@ -99,19 +97,6 @@ export const macadamMachinesStatuses = new Map<string, extensionApi.ProviderConn
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   console.log('starting bootc extension');
-
-  // Ensure version is above the minimum Podman Desktop version required
-  const version = extensionApi.version ?? 'unknown';
-  if (!checkVersion(version)) {
-    const min = minVersion(engines['podman-desktop']);
-    telemetryLogger.logError('start.incompatible', {
-      version: version,
-      message: `error activating extension on version below ${min?.version}`,
-    });
-    throw new Error(
-      `Extension is not compatible with Podman Desktop version below ${min?.version} (Current ${version}).`,
-    );
-  }
 
   telemetryLogger.logUsage('start');
 
@@ -209,19 +194,6 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       macadamEvents.emit(MACADAM_INITIALIZED_EVENT);
     }
   }
-}
-
-function checkVersion(version: string): boolean {
-  if (!version) {
-    return false;
-  }
-
-  const current = coerce(version);
-  if (!current) {
-    return false;
-  }
-
-  return satisfies(current, engines['podman-desktop']);
 }
 
 export async function openBuildPage(


### PR DESCRIPTION
### What does this PR do?

This removes the startup Podman Desktop version check entirely.

The check was added originally to ensure a minimum PD version, but we've been unable to update it because the extension catalog allowed you to install on older versions (and then we'd just fail, not a great user experience).

Now that the catalog is checking, by the time we could bump this (when enough users are on PD 1.25+) there is no need, because PD is checking it. So, removing the code to simplify and avoid any future chance of it causing issues.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #2259.

### How to test this PR?

Just code review, PR checks should pass.