### PR TITLE
chore: update bootc status icon

### DIFF
--- a/packages/frontend/src/lib/BootcStatusIcon.spec.ts
+++ b/packages/frontend/src/lib/BootcStatusIcon.spec.ts
@@ -30,6 +30,7 @@ test('Expect running status to display correct background color', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('title', status);
   expect(icon).toHaveClass('bg-[var(--pd-status-created)]');
+  expect(icon).not.toHaveClass('text-xs');
 });
 
 test('Expect success status to display green background', async () => {
@@ -74,4 +75,14 @@ test('Expect used status to display green background', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('title', status);
   expect(icon).toHaveClass('bg-[var(--pd-status-running)]');
+});
+
+test('Expect unused status to display correct border', async () => {
+  const status = 'unused';
+  render(BootcStatusIcon, { status });
+  const icon = screen.getByRole('status');
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveAttribute('title', status);
+  expect(icon).toHaveClass('border-2');
+  expect(icon).toHaveClass('border-[var(--pd-status-not-running)]');
 });

--- a/packages/frontend/src/lib/BootcStatusIcon.svelte
+++ b/packages/frontend/src/lib/BootcStatusIcon.svelte
@@ -27,11 +27,12 @@ let IconComponent = $derived(icon);
 
 <div class="grid place-content-center" style="position:relative">
   <div
-    class="grid place-content-center rounded-sm aspect-square text-xs"
+    class="grid place-content-center rounded-sm aspect-square"
     class:bg-[var(--pd-status-running)]={status === 'success' || status === 'used'}
     class:bg-[var(--pd-status-created)]={status === 'running'}
     class:bg-[var(--pd-status-terminated)]={status === 'error'}
     class:bg-[var(--pd-status-degraded)]={status === 'lost'}
+    class:border-2={!solid && status !== 'deleting'}
     class:p-0.5={!solid}
     class:p-1={solid}
     class:border-[var(--pd-status-not-running)]={!solid}


### PR DESCRIPTION
### What does this PR do?

Applies the same fix as https://github.com/podman-desktop/podman-desktop/pull/15859 (which probably doesn't matter in our context).

Fixes the missing border for bootc Images (was missing the class:border-2 line, copied from PD StatusIcon).

### Screenshot / video of UI

Before:

<img width="163" height="225" alt="Screenshot 2026-01-28 at 2 25 16 PM" src="https://github.com/user-attachments/assets/676a1d23-b6e2-4c52-99ee-ec9546e561df" />

After:

<img width="163" height="225" alt="Screenshot 2026-01-28 at 2 24 35 PM" src="https://github.com/user-attachments/assets/b6360965-e3b6-42ac-a6ae-68443a849ddd" />

### What issues does this PR fix or reference?

Fixes #2260.

### How to test this PR?

Just check the Images page.