### PR TITLE
chore: update security and code of conduct links

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,3 +1,3 @@
-## The Podman Desktop Extension BootC Project Community Code of Conduct
+## Community Code of Conduct
 
-The Podman Desktop Extension BootC Project follows the [Containers Community Code of Conduct](https://github.com/containers/common/blob/main/CODE-OF-CONDUCT.md).
+This project follows the Podman Desktop [Community Code of Conduct](https://github.com/podman-desktop/podman-desktop/blob/main/CODE-OF-CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
-## Security and Disclosure Information Policy for the Podman Desktop Extension BootC Project
+## Security and Disclosure Information Policy
 
-The Podman Desktop Extension BootC Project follows the [Security and Disclosure Information Policy](https://github.com/containers/common/blob/main/SECURITY.md) for the Containers Projects.
+This project follows the Podman Desktop [Security and Disclosure Information Policy](https://github.com/podman-desktop/podman-desktop/blob/main/SECURITY.md).

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- l***********************************************************************/
+ ***********************************************************************/
 
 import type { BootcBuildInfo, BuildType } from './models/bootc';
 import type { ImageInfo, ImageInspectInfo, ManifestInspectInfo, ContainerInfo } from '@podman-desktop/api';


### PR DESCRIPTION
### What does this PR do?

Updated code of conduct and security to point to the Podman Desktop org policies instead of the containers org.

Simplified the titles and links a bit to make it readable.

Bonus fix: AI review tools often complain about the extra character in the comment even when unrelated, removing it to simplify future PRs...

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #2262.

### How to test this PR?

Just review the files, try the links.