### PR TITLE
chore: strip unnecessary build info from telemetry

### DIFF
--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -118,8 +118,11 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History, ov
 
   // remove paths, user info, and other potentially identifiable info
   const buildInfo = structuredClone(build);
+  buildInfo.image = 'image';
   if (buildInfo.buildConfig) {
-    buildInfo.buildConfig.user = undefined;
+    if (buildInfo.buildConfig.user) {
+      buildInfo.buildConfig.user = [];
+    }
     buildInfo.buildConfig.anacondaIsoInstallerKickstartFilePath = undefined;
     buildInfo.buildConfig.filesystem = undefined;
   }
@@ -127,6 +130,9 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History, ov
   buildInfo.awsAmiName = undefined;
   if (buildInfo.buildConfigFilePath) {
     buildInfo.buildConfigFilePath = 'user-path';
+  }
+  if (buildInfo.chown) {
+    buildInfo.chown = 'chown';
   }
   buildInfo.folder = 'folder';
   telemetryData.build = buildInfo;


### PR DESCRIPTION
### What does this PR do?

Strips all folders, user info, and potentially identifiable info from the telemetry logged for builds.

We do not have a full test for building images, so I cannot easily add this to a test. Fix has been verified by testing and tracing.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #2280.

### How to test this PR?

Run a build, filling out as much detail as possible with easily recognizable strings for all paths, user info, mount point, AWS bucket. Check the dev telemetry to ensure none of these strings escape.