### PR TITLE
chore(package): add explicit eslint/js depenency to allow update

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@commitlint/cli": "^20.4.1",
     "@commitlint/config-conventional": "^20.4.1",
     "@eslint/compat": "^2.0.2",
+    "@eslint/js": "^9.39.2",
     "@typescript-eslint/eslint-plugin": "^8.55.0",
     "@typescript-eslint/parser": "^8.55.0",
     "@vitest/coverage-v8": "^4.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@eslint/compat':
         specifier: ^2.0.2
         version: 2.0.2(eslint@9.39.2(jiti@2.6.1))
+      '@eslint/js':
+        specifier: ^9.39.2
+        version: 9.39.2
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.55.0
         version: 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)


### PR DESCRIPTION
### What does this PR do?

This PR explicitely adds the development dependency for `@eslint/js` that seems to be not included automatically by eslint major version 10 in this dependabot update (see pnpm-lock for details). https://github.com/podman-desktop/extension-bootc/pull/2288 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Helps to unblock https://github.com/podman-desktop/extension-bootc/pull/2288

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
