### PR TITLE
chore(test): check for error reason before marking test as failed

### DIFF
--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -350,7 +350,7 @@ test.describe('BootC Extension', () => {
                       await playExpect(tasksPage.heading).toBeVisible();
                       const failureFullText = await tasksPage.getStatusForLatestTask();
 
-                      if (failureFullText.includes('Can also be that registry requires authentication')) {
+                      if (failureFullText.includes('Can also be that the registry requires authentication')) {
                         console.log('Could not pull rhel image from registry, skipping test');
                         test.skip();
                         return;


### PR DESCRIPTION
### What does this PR do?
Analyzes the error message for the rhel bootc test and markes the test as skipped if rhel image could not be retrieved 

### What issues does this PR fix or reference?