### PR TITLE
fix(build): cache checkPrereqs and debounce validation to fix windows timeouts

### DIFF
--- a/packages/backend/src/machine-utils.ts
+++ b/packages/backend/src/machine-utils.ts
@@ -85,9 +85,12 @@ async function readMachineConfig(machineConfigDir: string, currentMachine: strin
 }
 
 // Check if the current podman machine is rootful
-export async function isPodmanMachineRootful(connection: extensionApi.ContainerProviderConnection): Promise<boolean> {
+export async function isPodmanMachineRootful(
+  connection: extensionApi.ContainerProviderConnection,
+  existingMachineInfo?: unknown,
+): Promise<boolean> {
   try {
-    const machineInfo = await getMachineInfo(connection);
+    const machineInfo = existingMachineInfo ?? (await getMachineInfo(connection));
     const machineConfig = await readMachineConfig(machineInfo.Host.MachineConfigDir, getPodmanMachineName(connection));
 
     // If you are on Podman Machine 4.9.0 with applehv activated, the rootful key will be located
@@ -113,9 +116,12 @@ export async function isPodmanMachineRootful(connection: extensionApi.ContainerP
 }
 
 // Check if the current podman machine is v5 or above
-export async function isPodmanV5Machine(connection: extensionApi.ContainerProviderConnection): Promise<boolean> {
+export async function isPodmanV5Machine(
+  connection: extensionApi.ContainerProviderConnection,
+  existingMachineInfo?: unknown,
+): Promise<boolean> {
   try {
-    const machineInfo = await getMachineInfo(connection);
+    const machineInfo = existingMachineInfo ?? (await getMachineInfo(connection));
 
     const ver = machineInfo.Version.Version;
     // Attempt to parse the version, handling undefined if it fails
@@ -137,12 +143,15 @@ export async function isPodmanV5Machine(connection: extensionApi.ContainerProvid
 export async function checkPrereqs(connection: extensionApi.ContainerProviderConnection): Promise<string | undefined> {
   // Podman Machine checks are applicable to non-Linux platforms only
   if (!isLinux()) {
-    const isPodmanV5 = await isPodmanV5Machine(connection);
+    // Get machine info once and pass to both checks to avoid duplicate podman CLI calls
+    const machineInfo = await getMachineInfo(connection);
+
+    const isPodmanV5 = await isPodmanV5Machine(connection, machineInfo);
     if (!isPodmanV5) {
       return 'Podman v5.0 or higher is required to build disk images.';
     }
 
-    const isRootful = await isPodmanMachineRootful(connection);
+    const isRootful = await isPodmanMachineRootful(connection, machineInfo);
     if (!isRootful) {
       return 'The podman machine is not set as rootful. Please recreate the podman machine with rootful privileges set and try again.';
     }

--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -243,20 +243,12 @@ test('Check that prereq validation works', async () => {
 
   render(Build);
 
-  // Wait until children length is 2 meaning it's fully rendered / propagated the changes
+  // When checkPrereqs returns an error on mount, the form shows a full-screen error
+  // and does not render the rest of the form
   await vi.waitFor(() => {
-    if (screen.getByLabelText('image-select')?.children.length !== 2) {
-      throw new Error();
-    }
+    const errorScreen = screen.getByText(prereq);
+    expect(errorScreen).toBeDefined();
   });
-
-  // select an option to trigger validation
-  const raw = screen.getByLabelText('raw-checkbox');
-  raw.click();
-
-  const validation = screen.getByRole('alert');
-  expect(validation).toBeDefined();
-  expect(validation.textContent).toEqual(prereq);
 });
 
 test('Check that overwriting an existing build works', async () => {
@@ -286,11 +278,13 @@ test('Check that overwriting an existing build works', async () => {
   expect(validation).toBeDefined();
   expect(validation.textContent).toEqual('Confirm overwriting existing build');
 
-  // select the checkbox and give it time to validate
+  // select the checkbox and give it time to validate (debounced at 500ms)
   await userEvent.click(overwrite2);
 
-  const validation2 = screen.queryByRole('alert');
-  expect(validation2).toBeNull();
+  await vi.waitFor(() => {
+    const validation2 = screen.queryByRole('alert');
+    expect(validation2).toBeNull();
+  });
 });
 
 const fakedImageInspect: ImageInspectInfo = {
@@ -852,10 +846,12 @@ test('confirm successful build goes to logs', async () => {
   expect(overwriteCheck).toBeDefined();
   await userEvent.click(overwriteCheck);
 
-  // confirm build button is enabled
+  // confirm build button is enabled (wait for debounced validation)
   const build = screen.getByText('Build');
   expect(build).toBeInTheDocument();
-  expect(build).toBeEnabled();
+  await vi.waitFor(() => {
+    expect(build).toBeEnabled();
+  });
 
   // check that clicking redirects to the build logs page
   expect(router.goto).not.toHaveBeenCalled();

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -56,6 +56,13 @@ let bootcAvailableImages: ImageInfo[] = [];
 let buildErrorMessage = '';
 let errorFormValidation: string | undefined = undefined;
 
+// Cache the prereqs result so we don't call podman CLI on every form change
+let cachedPrereqs: string | undefined = undefined;
+let prereqsChecked = false;
+
+// Debounce timer for reactive validation
+let validateDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+
 // Specific to root filesystem selection
 // SPECIFICALLY fedora, where we **need** to select the filesystem, as it is not auto-selected.
 // this boolean will be set to true if the selected image is Fedora and shown as a warning to the user.
@@ -154,18 +161,21 @@ async function fillChownOption(): Promise<void> {
 }
 
 async function validate(): Promise<void> {
-  let prereqs;
-  // Wrapped around a try / catch so we do not have any unhandled promise rejections
-  try {
-    prereqs = await bootcClient.checkPrereqs();
-  } catch (err: unknown) {
-    errorFormValidation = String(err);
-    existingBuild = false;
-    return;
+  // Use cached prereqs result to avoid repeated podman CLI calls on every form change.
+  // Prereqs (podman version, rootful status) don't change during a session.
+  if (!prereqsChecked) {
+    try {
+      cachedPrereqs = await bootcClient.checkPrereqs();
+    } catch (err: unknown) {
+      errorFormValidation = String(err);
+      existingBuild = false;
+      return;
+    }
+    prereqsChecked = true;
   }
 
-  if (prereqs) {
-    errorFormValidation = prereqs;
+  if (cachedPrereqs) {
+    errorFormValidation = cachedPrereqs;
     existingBuild = false;
     return;
   }
@@ -428,11 +438,17 @@ onMount(async () => {
   // filter to images that have a repo tag here, to avoid doing it everywhere
   bootcAvailableImages = images.filter(image => image.RepoTags && image.RepoTags.length > 0);
 
-  // On mount do prerequisite check to see if podman machine is running correctly and then return the error message.
+  // Check prereqs once on mount and cache the result for all future validate() calls.
   try {
-    await bootcClient.checkPrereqs();
+    cachedPrereqs = await bootcClient.checkPrereqs();
+    prereqsChecked = true;
   } catch (err: unknown) {
     buildErrorMessage = String(err);
+    return;
+  }
+
+  if (cachedPrereqs) {
+    buildErrorMessage = cachedPrereqs;
     return;
   }
 
@@ -532,8 +548,14 @@ async function updateBuildType(type: BuildType, selected: boolean): Promise<void
 }
 
 // validate every time a selection changes in the form or available architectures
+// debounced to avoid spamming API calls (e.g. when typing in the build folder path)
 $: if (selectedImage || buildFolder || buildArch || overwrite) {
-  validate().catch((e: unknown) => console.error('error validating on change', e));
+  if (validateDebounceTimer) {
+    clearTimeout(validateDebounceTimer);
+  }
+  validateDebounceTimer = setTimeout(() => {
+    validate().catch((e: unknown) => console.error('error validating on change', e));
+  }, 500);
 }
 
 // Each time an image is selected, we need to update the available architectures


### PR DESCRIPTION
fix(build): cache checkPrereqs and debounce validation to fix windows timeouts

### What does this PR do?

Cache `checkPrereqs()` results and debounce form validation to fix the
timeout error encountered on the bootc build page on Windows.

The cause was that `checkPrereqs()` was being called on every form
change (including each keystroke when typing the output folder path).

At one point.. it would call it 17 times while typing it in, so in a CI
scenario, it was validating WAY too much.

On Windows/WSL, each `checkPrereqs()` call runs `podman machine info`
via CLI which is very slow. Works fine on macOS (a bit faster), and very
fast on Linux (since podman machine wasn't needed).

I did the following:

* Cache `checkPrereqs()` result on mount and reuse it in `validate()`,
  since podman version and rootful status don't change during a session

* Remove duplicate `checkPrereqs()` call on mount (was called in
  `onMount` and again inside `validate()`)

* Add 500ms debounce so it triggers after it's all typed in.

* Call getMachineInfo once in prereqs, rather than multiple times.

### Screenshot / video of UI

N/A, no UI changes.

### What issues does this PR fix or reference?

Fixes #1701

### How to test this PR?

1. Run on Windows (or macOS.. but error isn't hit as often)
2. Go to Build Disk image page
3. Confirm no timeout issue
4. Type path in the output folder and don't see any errors / validation
   issues..

There's a few tests covering this as well!

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
