### PR TITLE
chore: remove CODEOWNERS file for bot assignment

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# Default Owners
-* @podman-desktop/reviewers


### PR DESCRIPTION
### What does this PR do?
the podman desktop bot will add people for specific area so no longer needing the CODEOWNERS file with random assignees


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
