### PR TITLE
chore(dependabot): use a fixed time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,16 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+      # check at 2am UTC
+      time: "02:00"
     open-pull-requests-limit: 10
 
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: daily
+      # check at 2am UTC
+      time: "02:00"
     open-pull-requests-limit: 10
     groups:
       fortawesome:


### PR DESCRIPTION
### What does this PR do?
avoid to throw dependabot PR at unknown time (last time we edited the dependabot file)
make it happen during the "night" so it's ready/merged in the morning

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
