### PR TITLE
chore(revert): reverts 0.15.0 bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Bootable Container",
   "description": "Support for bootable OS containers (bootc) and generating disk images",
   "repository": "https://github.com/podman-desktop/extension-bootc",
-  "version": "1.15.0-next",
+  "version": "1.14.0-next",
   "icon": "icon.png",
   "publisher": "redhat",
   "private": true,

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -2,7 +2,7 @@
   "name": "bootc",
   "displayName": "Bootable Container",
   "description": "Support for bootable OS containers (bootc) and generating disk images",
-  "version": "1.15.0-next",
+  "version": "1.14.0-next",
   "icon": "icon.png",
   "publisher": "redhat",
   "license": "Apache-2.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "displayName": "frontend UI",
   "description": "Frontend UI for the bootc extension",
-  "version": "1.15.0-next",
+  "version": "1.14.0-next",
   "type": "module",
   "scripts": {
     "preview": "vite preview",


### PR DESCRIPTION
chore(revert): reverts 0.15.0 bump

### What does this PR do?

Reverts the 0.15.0 bump so we can re-release 0.14.0 without our release
action failing.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
