### PR TITLE
fix: resolve CVE-2026-33228 in flatted

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "overrides": {
       "vite>esbuild": "^0.25.0",
       "minimatch@<3.1.3": "~3.1.3",
-      "minimatch@>=9.0.0 <9.0.4": "~9.0.4"
+      "minimatch@>=9.0.0 <9.0.4": "~9.0.4",
+      "flatted@<3.4.2": ">=3.4.2"
     },
     "ignoredBuiltDependencies": [
       "@biomejs/biome",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   vite>esbuild: ^0.25.0
   minimatch@<3.1.3: ~3.1.3
   minimatch@>=9.0.0 <9.0.4: ~9.0.4
+  flatted@<3.4.2: '>=3.4.2'
 
 importers:
 
@@ -2365,8 +2366,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -6000,10 +6001,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   for-each@0.3.5:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-33228 in `flatted`.

**Advisory**: Prototype Pollution via parse() in NodeJS flatted
**Vulnerable versions**: <=3.4.1
**Patched versions**: >=3.4.2
**Advisory URL**: https://github.com/advisories/GHSA-rf6f-7fwh-wjgh

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-33228: _Prototype Pollution via parse() in NodeJS flatted_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-33228 is no longer reported