### PR TITLE
fix: resolve CVE-2026-33671 in picomatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
       "vite>esbuild": "^0.25.0",
       "minimatch@<3.1.3": "~3.1.3",
       "minimatch@>=9.0.0 <9.0.4": "~9.0.4",
-      "flatted@<3.4.2": ">=3.4.2"
+      "flatted@<3.4.2": ">=3.4.2",
+      "picomatch@>=4.0.0 <4.0.4": ">=4.0.4"
     },
     "ignoredBuiltDependencies": [
       "@biomejs/biome",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   minimatch@<3.1.3: ~3.1.3
   minimatch@>=9.0.0 <9.0.4: ~9.0.4
   flatted@<3.4.2: '>=3.4.2'
+  picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
 
 importers:
 
@@ -2337,7 +2338,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: '>=4.0.4'
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -3073,10 +3074,6 @@ packages:
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -6457,7 +6454,7 @@ snapshots:
     dependencies:
       commander: 14.0.3
       listr2: 9.0.5
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       string-argv: 0.3.2
       tinyexec: 1.0.4
       yaml: 2.8.2
@@ -6668,8 +6665,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
-
-  picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
 
@@ -7402,7 +7397,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
@@ -7440,7 +7435,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 1.0.2


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-33671 in `picomatch`.

**Advisory**: Picomatch has a ReDoS vulnerability via extglob quantifiers
**Vulnerable versions**: >=4.0.0 <4.0.4
**Patched versions**: >=4.0.4
**Advisory URL**: https://github.com/advisories/GHSA-c2c7-rcm5-vvqj

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-33671: _Picomatch has a ReDoS vulnerability via extglob quantifiers_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-33671 is no longer reported