### PR TITLE
fix: resolve CVE-2025-69873 in ajv 

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
       "minimatch@<3.1.3": "~3.1.3",
       "minimatch@>=9.0.0 <9.0.4": "~9.0.4",
       "flatted@<3.4.2": ">=3.4.2",
-      "picomatch@>=4.0.0 <4.0.4": ">=4.0.4"
+      "picomatch@>=4.0.0 <4.0.4": ">=4.0.4",
+      "ajv@<6.14.0": ">=6.14.0 <7.0.0"
     },
     "ignoredBuiltDependencies": [
       "@biomejs/biome",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   minimatch@>=9.0.0 <9.0.4: ~9.0.4
   flatted@<3.4.2: '>=3.4.2'
   picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
+  ajv@<6.14.0: '>=6.14.0 <7.0.0'
 
 importers:
 
@@ -1660,8 +1661,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
@@ -4401,7 +4402,7 @@ snapshots:
 
   '@eslint/eslintrc@3.3.3':
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.15.0
       debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
@@ -5148,7 +5149,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  ajv@6.12.6:
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -5892,7 +5893,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.12.6
+      ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2025-69873 in `ajv`.

**Advisory**: ajv has ReDoS when using `$data` option
**Vulnerable versions**: <6.14.0
**Patched versions**: >=6.14.0
**Advisory URL**: https://github.com/advisories/GHSA-2g4f-4pwh-qvx6

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2025-69873: _ajv has ReDoS when using `$data` option_

### How to test this PR?

Run `pnpm audit` and verify CVE-2025-69873 is no longer reported