### PR TITLE
feat(agents): add agents + skills to bootc extension

### DIFF
--- a/.agents/skills/backend-api/SKILL.md
+++ b/.agents/skills/backend-api/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: backend-api
+description: >-
+  Guides backend development with @podman-desktop/api and the bootc extension's
+  RPC system. Covers container engine operations, provider management, RPC
+  communication, build orchestration, VM management, and configuration. Triggers
+  when working on packages/backend/ code, adding RPC methods to BootcAPI,
+  implementing container/image operations, or asking about backend patterns.
+paths:
+  - packages/backend/src/**/*.ts
+  - packages/shared/src/**/*.ts
+---
+
+# Backend API Development Guide
+
+## Extension API: @podman-desktop/api
+
+The backend runs as a Podman Desktop extension in Node.js. All host interactions
+go through `@podman-desktop/api`, which is provided by the Podman Desktop runtime
+(not bundled — it's an external dependency).
+
+```typescript
+import * as extensionApi from '@podman-desktop/api';
+```
+
+### Check API
+
+API signatures change across versions. Read the installed types directly:
+
+1. **Full API types**: Read `node_modules/@podman-desktop/api/index.d.ts`
+2. **Current RPC contract**: Read `packages/shared/src/BootcAPI.ts`
+3. **Current models**: Read files in `packages/shared/src/models/`
+4. **Current messages**: Read `packages/shared/src/messages/Messages.ts`
+5. **See existing usage**: `grep -r "extensionApi\." packages/backend/src/`
+
+Always verify method signatures against the actual type definitions before using them.
+
+## RPC Architecture
+
+Frontend ↔ Backend communication uses a typed RPC proxy over webview `postMessage`.
+
+### Adding a New API Method
+
+**Step 1: Define in shared contract** (`packages/shared/src/BootcAPI.ts`):
+
+```typescript
+export abstract class BootcApi {
+  // ... existing methods
+  abstract myNewMethod(param: string): Promise<ResultType>;
+}
+```
+
+**Step 2: Implement in backend** (`packages/backend/src/api-impl.ts`):
+
+```typescript
+export class BootcApiImpl extends BootcApi {
+  async myNewMethod(param: string): Promise<ResultType> {
+    const result = await extensionApi.containerEngine.listImages();
+    return transformResult(result);
+  }
+}
+```
+
+**Step 3: Call from frontend** (automatic — RPC proxy exposes all methods):
+
+```typescript
+import { bootcClient } from '/@/api/client';
+const result = await bootcClient.myNewMethod('value');
+```
+
+### RPC Timeout
+
+Default timeout is 5 seconds per RPC call. For long-running operations, add
+the method name to the no-timeout list:
+
+```bash
+cat packages/shared/src/messages/NoTimeoutChannels.ts
+```
+
+### Sending Notifications (Backend → Frontend)
+
+Push data to the frontend via message IDs. See the current messages:
+
+```bash
+cat packages/shared/src/messages/Messages.ts
+```
+
+Send from backend:
+
+```typescript
+this.panel.webview.postMessage({ id: Messages.MSG_HISTORY_UPDATE, body: data });
+```
+
+Frontend subscribes via RPC:
+
+```typescript
+import { rpcBrowser } from '/@/api/client';
+rpcBrowser.subscribe(Messages.MSG_NAVIGATE_BUILD, (path: string) => {
+  router.goto(`/disk-images/build/${path}`);
+});
+```
+
+## Discovering APIs
+
+APIs change across versions. Always read the source rather than relying on memory.
+
+### @podman-desktop/api
+
+```bash
+# Full API surface — the single source of truth
+cat node_modules/@podman-desktop/api/index.d.ts
+
+# Find how specific APIs are already used in this codebase
+grep -rn "extensionApi\.\(containerEngine\|window\|provider\|navigation\|configuration\|process\|env\)" packages/backend/src/
+```
+
+### Internal helpers
+
+```bash
+# Key backend modules — read these to find available helpers
+ls packages/backend/src/*.ts
+ls packages/shared/src/models/
+```
+
+## Checklist: Adding a New Backend Feature
+
+1. Add abstract method to `packages/shared/src/BootcAPI.ts`
+2. Implement in `packages/backend/src/api-impl.ts`
+3. If long-running (>5s), add to `NoTimeoutChannels.ts`
+4. If it pushes data to frontend, add a message to `Messages.ts`
+5. Add types/models in `packages/shared/src/models/` if needed
+6. Add telemetry for usage and errors
+7. Write unit tests mocking `@podman-desktop/api`
+8. Frontend can call via `bootcClient.myNewMethod()` — no wiring needed

--- a/.agents/skills/extension-development/SKILL.md
+++ b/.agents/skills/extension-development/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: extension-development
+description: >-
+  Guides end-to-end feature development in the bootc Podman Desktop extension.
+  Covers the extension lifecycle, architecture overview, RPC communication,
+  build system, and extension points. Triggers when adding features spanning
+  backend and frontend, understanding the extension lifecycle, or needing an
+  architectural overview of how the pieces connect.
+---
+
+# Bootc Extension Development Guide
+
+## Extension Lifecycle
+
+### Entry Point (`packages/backend/src/extension.ts`)
+
+`activate()` runs when Podman Desktop loads the extension. `deactivate()` cleans
+up. Read the file to see the current initialization sequence:
+
+```bash
+cat packages/backend/src/extension.ts
+```
+
+## Architecture
+
+Three packages in `packages/`:
+
+- **Frontend** (`packages/frontend/`) — Svelte 5 webview UI. Root component: `src/App.svelte`. Reactive stores in `src/stores/`. Builds into `../backend/media/`.
+- **Shared** (`packages/shared/`) — Typed API contract (`src/BootcAPI.ts`), data models (`src/models/`), and notification messages (`src/messages/Messages.ts`). Both frontend and backend depend on this package.
+- **Backend** (`packages/backend/`) — Node.js extension host. Entry: `src/extension.ts`. Implements the shared API contract in `src/api-impl.ts` (`BootcApiImpl`). Uses `@podman-desktop/api` for Podman Desktop integration.
+
+**Data flow**: Frontend calls `bootcClient.method()` → RPC `MessageProxy` serializes the call over webview `postMessage` → Backend `BootcApiImpl` handles it and returns the result back through the same channel. Backend pushes notifications to the frontend via `Messages` enum events.
+
+For detailed UI patterns, see the **svelte-ui-design** skill.
+For detailed backend API patterns, see the **backend-api** skill.
+
+### RPC Communication
+
+Frontend ↔ Backend uses a typed RPC proxy over webview `postMessage`:
+
+- **Contract**: `packages/shared/src/BootcAPI.ts` — abstract class defining every method the frontend can call
+- **Implementation**: `packages/backend/src/api-impl.ts` — `BootcApiImpl` extends the contract with real logic
+- **Client**: `packages/frontend/src/api/client.ts` — hand-written file that creates a typed proxy at runtime via `rpcBrowser.getProxy<BootcApi>(BootcApi)`. Any method added to the abstract contract is automatically available on `bootcClient` without modifying this file.
+- **Notifications**: `Messages` enum in `packages/shared/src/messages/Messages.ts` — backend-to-frontend push events
+
+See the **backend-api** skill for detailed RPC patterns and examples.
+
+## Adding a New Feature (End-to-End)
+
+1. **Define API** — Add abstract method to `packages/shared/src/BootcAPI.ts`
+2. **Implement** — Add implementation to `packages/backend/src/api-impl.ts` (see **backend-api** skill)
+3. **Call from frontend** — Use `bootcClient.myNewMethod()` from `/@/api/client` (auto-proxied)
+4. **Add route** — Add `<Route>` in `App.svelte`, navigation in `Navigation.svelte`
+5. **Add models** — Define types in `packages/shared/src/models/` if needed
+6. **Build UI** — See **svelte-ui-design** skill for layout and component patterns
+
+## Build System
+
+### Vite Configuration
+
+**Backend** (`packages/backend/vite.config.js`):
+
+- Library mode, CJS output → `dist/extension.js`
+- Externals: `@podman-desktop/api`, `ssh2`, Node.js builtins
+- Aliases: `/@/` → `src/`, `/@shared/` → `../../shared/`
+
+**Frontend** (`packages/frontend/vite.config.js`):
+
+- Svelte + Tailwind CSS plugins
+- Output → `../backend/media/`
+- Aliases: `/@/` → `src/`, `/@shared/` → `../../shared/`
+
+### Development Watch
+
+```bash
+pnpm watch  # Watches all packages concurrently
+```
+
+Frontend changes rebuild into `packages/backend/media/`, which Podman Desktop
+picks up when using `--extension-folder`.
+
+## Extension Points (package.json)
+
+### Extension Points
+
+Configuration properties, menu contributions, commands, icons, and views are
+all defined in `package.json` under `contributes`. Read it for the current state:
+
+```bash
+# See all extension points (configuration, menus, commands, views, icons)
+cat packages/backend/package.json | grep -A 200 '"contributes"'
+```
+
+## Telemetry
+
+Telemetry example:
+
+```typescript
+telemetryLogger.logUsage('buildDiskImage', { type: 'qcow2', arch: 'arm64' });
+telemetryLogger.logError('buildFailed', { error: errorMessage });
+```

--- a/.agents/skills/playwright-testing/SKILL.md
+++ b/.agents/skills/playwright-testing/SKILL.md
@@ -1,0 +1,337 @@
+---
+name: playwright-testing
+description: >-
+  Guides writing and maintaining Playwright E2E tests for the bootc Podman
+  Desktop extension. Covers the webview-aware test framework, extension
+  lifecycle management, Page Object Models, and spec file patterns. Triggers
+  when creating or modifying E2E spec files, building page object models,
+  debugging Playwright failures, or asking about the test framework.
+paths:
+  - tests/playwright/**/*.ts
+---
+
+# Playwright E2E Testing for Bootc Extension
+
+This extension runs inside Podman Desktop as a webview. E2E tests launch Podman
+Desktop via Electron, install the extension from an OCI image, then interact
+with the extension's webview UI. This is fundamentally different from testing
+Podman Desktop itself — every test must handle the webview boundary.
+
+## Project Structure
+
+Tests live in `tests/playwright/`. Key directories:
+
+- `src/*.spec.ts` — test spec files
+- `src/model/` — Page Object Models (webview-aware, take both `page` and `webview`)
+- `src/utility/` — test helpers (webview handling, extension lifecycle, cleanup)
+
+```bash
+# See the full structure
+find tests/playwright/src -type f -name '*.ts' | sort
+```
+
+## Critical Concept: Webview Handling
+
+Extensions render in a webview (a separate Electron BrowserWindow). You must
+get BOTH the main page and the webview page to interact with extension UI:
+
+```typescript
+import { handleWebview } from './utility/bootc-test-utils';
+
+// Returns [mainPage, webViewPage] — use webViewPage for extension UI locators
+const [page, webview] = await handleWebview(runner);
+```
+
+**How `handleWebview()` works:**
+
+1. Clicks the "Bootable Containers" link in Podman Desktop's main navigation
+2. Waits for the webview document to appear
+3. Gets the second Electron window via `runner.getWindows()`
+4. Focuses the webview element
+5. Returns `[mainPage, webViewPage]`
+
+**All extension Page Object Models take both `page` and `webview` parameters.**
+Use `webview` for extension-specific locators, `page` for Podman Desktop dialogs.
+
+## Imports
+
+Import `test`, `expect`, and utilities from `@podman-desktop/tests-playwright`:
+
+```typescript
+import {
+  test,
+  expect as playExpect,
+  RunnerOptions,
+  removeFolderIfExists,
+  waitForPodmanMachineStartup,
+  NavigationBar,
+  waitUntil,
+} from '@podman-desktop/tests-playwright';
+import type { Page } from '@playwright/test';
+```
+
+Import extension-specific models and utilities locally:
+
+```typescript
+import { BootcNavigationBar } from './model/bootc-navigationbar';
+import {
+  handleWebview,
+  installBootcExtensionIfNeeded,
+  removeBootcExtensionIfNeeded,
+  cleanupRawVideoFiles,
+} from './utility/bootc-test-utils';
+import { markTestFileComplete } from './utility/extension-lifecycle';
+```
+
+## Extension Lifecycle Management
+
+The extension is installed once before the first spec file and removed after the
+last one completes. This is managed by a file-based counter:
+
+1. `global-setup.ts` counts spec files and writes the total to a temp file
+2. Each spec's `afterAll` calls `markTestFileComplete(fileId)` which decrements
+3. When the counter reaches zero, the last spec file triggers removal
+4. `extension-reporter.ts` handles fully-skipped files (their afterAll never runs)
+
+**Every spec file MUST include this in its outer `test.afterAll`:**
+
+```typescript
+import { fileURLToPath } from 'node:url';
+import { markTestFileComplete } from './utility/extension-lifecycle';
+
+const __filename = fileURLToPath(import.meta.url);
+
+test.afterAll(async ({ navigationBar }) => {
+  if (markTestFileComplete(__filename)) {
+    await removeBootcExtensionIfNeeded(navigationBar);
+  }
+});
+```
+
+## Page Object Model Pattern
+
+### Two-Parameter POMs
+
+Unlike upstream Podman Desktop POMs (which take only `page`), bootc POMs take
+both `page` and `webview`:
+
+```typescript
+export class BootcDashboardPage {
+  readonly page: Page;
+  readonly webview: Page;
+  readonly heading: Locator;
+
+  constructor(page: Page, webview: Page) {
+    this.page = page;
+    this.webview = webview;
+    // Extension UI locators use webview
+    this.heading = webview.getByText('Welcome to bootable containers');
+  }
+}
+```
+
+### Using POMs
+
+POMs are in `tests/playwright/src/model/`. Read them for current methods and locators:
+
+```bash
+ls tests/playwright/src/model/
+```
+
+The navigation bar POM navigates within the extension's webview. Other POMs
+wrap specific pages (build, dashboard, disk images, examples, etc.).
+
+### Dialog Handling
+
+Build completion shows a dialog on the **main page** (not webview). Always
+use `this.page` (not `this.webview`) for Podman Desktop dialogs.
+
+## Writing a New Spec File
+
+### Template
+
+```typescript
+import type { Page } from '@playwright/test';
+import {
+  removeFolderIfExists,
+  waitForPodmanMachineStartup,
+  test,
+  expect as playExpect,
+  RunnerOptions,
+  isLinux,
+} from '@podman-desktop/tests-playwright';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { BootcNavigationBar } from './model/bootc-navigationbar';
+import {
+  removeBootcExtensionIfNeeded,
+  handleWebview,
+  installBootcExtensionIfNeeded,
+  cleanupRawVideoFiles,
+} from './utility/bootc-test-utils';
+import { markTestFileComplete } from './utility/extension-lifecycle';
+
+let page: Page;
+let webview: Page;
+const __filename = fileURLToPath(import.meta.url);
+
+test.use({
+  runnerOptions: new RunnerOptions({
+    customFolder: 'bootc-tests-pd',
+    customOutputFolder: 'tests/output',
+    autoUpdate: false,
+    autoCheckUpdates: false,
+  }),
+});
+
+test.beforeAll(async ({ runner, welcomePage, page }) => {
+  await removeFolderIfExists('tests/output/images');
+  runner.setVideoAndTraceName('my-feature-name');
+  await welcomePage.handleWelcomePage(true);
+  await waitForPodmanMachineStartup(page);
+});
+
+test.afterAll(async ({ runner }) => {
+  test.setTimeout(320_000);
+  const videoAndTraceName = runner.getVideoAndTraceName();
+  try {
+    await removeFolderIfExists('tests/output/images');
+  } finally {
+    await runner.close(200_000);
+    cleanupRawVideoFiles('tests/output', videoAndTraceName);
+  }
+});
+
+test.describe('My Feature', () => {
+  test.skip(isLinux); // building bootable images not supported on Linux
+
+  test.beforeAll(async ({ navigationBar }) => {
+    test.setTimeout(200_000);
+    await installBootcExtensionIfNeeded(navigationBar);
+  });
+
+  test.describe.serial('Feature flow', () => {
+    test('Navigate to extension', async ({ runner }) => {
+      test.setTimeout(60_000);
+      [page, webview] = await handleWebview(runner);
+      const bootcNav = new BootcNavigationBar(page, webview);
+      const dashboard = await bootcNav.openBootcDashboard();
+      await playExpect(dashboard.heading).toBeVisible();
+    });
+
+    test('Perform action', async ({ runner }) => {
+      test.setTimeout(300_000);
+      [page, webview] = await handleWebview(runner);
+      // ... test body
+    });
+  });
+
+  test.afterAll(async ({ navigationBar }) => {
+    if (markTestFileComplete(__filename)) {
+      await removeBootcExtensionIfNeeded(navigationBar);
+    }
+  });
+});
+```
+
+### Key Patterns
+
+- **Always call `handleWebview(runner)`** at the start of each test that interacts with the extension
+- **Use `test.describe.serial()`** — tests share Electron state and must run in order
+- **Use `test.skip(isLinux)`** — building bootable images is not supported on Linux
+- **Long timeouts are normal** — image pulls take up to 12 minutes, builds up to 25 minutes
+- **Clean up video files** — call `cleanupRawVideoFiles()` in `afterAll` to handle orphaned webview recordings
+- **`customFolder: 'bootc-tests-pd'`** — all specs use this folder name for consistent profile isolation
+
+### Platform Skip Patterns
+
+```typescript
+import { isLinux, isMac, isWindows } from '@podman-desktop/tests-playwright';
+
+test.skip(isLinux); // no bootable image building on Linux
+test.skip(isMac && arch === ArchitectureType.AMD64, 'amd64 not supported on macOS');
+test.skip(isWindows && arch === ArchitectureType.ARM64, 'arm64 not supported on Windows');
+```
+
+## Extension Installation
+
+The extension is installed from an OCI image. The URL is configurable:
+
+```typescript
+// Default: ghcr.io/podman-desktop/extension-bootc:next
+// Override: set OCI_IMAGE env var
+const extensionURL = process.env.OCI_IMAGE ?? 'ghcr.io/podman-desktop/extension-bootc:next';
+```
+
+Set `SKIP_INSTALLATION=true` to skip install/remove (when testing with a pre-installed extension).
+
+## Running Tests
+
+```bash
+# From the repo root
+pnpm test:e2e
+
+# From tests/playwright directly
+pnpm --dir tests/playwright test:e2e
+
+# Run a single spec
+pnpm --dir tests/playwright exec playwright test src/bootc-dashboard.spec.ts
+
+# With custom extension image
+OCI_IMAGE=ghcr.io/podman-desktop/extension-bootc:v1.15.0 \
+  pnpm --dir tests/playwright exec playwright test src/
+
+# Skip extension install/remove (pre-installed)
+SKIP_INSTALLATION=true \
+  pnpm --dir tests/playwright exec playwright test src/
+```
+
+### Environment Variables
+
+| Variable                | Purpose                                      |
+| ----------------------- | -------------------------------------------- |
+| `PODMAN_DESKTOP_BINARY` | Path to Podman Desktop binary                |
+| `PODMAN_DESKTOP_ARGS`   | Path to Podman Desktop repo (dev mode)       |
+| `OCI_IMAGE`             | Extension OCI image URL (default: next tag)  |
+| `SKIP_INSTALLATION`     | Skip extension install/remove lifecycle      |
+| `BUILD_ISO_IMAGE`       | Enable ISO build tests (disabled by default) |
+
+## Existing Spec Files
+
+```bash
+# List all spec files and their test descriptions
+ls tests/playwright/src/*.spec.ts
+grep -h "test.describe\|test('" tests/playwright/src/*.spec.ts
+```
+
+## Troubleshooting
+
+### Webview Not Appearing
+
+If `handleWebview()` times out waiting for the second window, the extension may
+not have loaded. Check that the extension is installed and in ACTIVE state.
+
+### Build Stuck in "creating" State
+
+`BootcPage.refreshPageWhileInCreatingState()` navigates away and back to force
+a UI refresh. The `waitUntil` wrapper retries until the state changes.
+
+### Video File Cleanup
+
+Webview windows generate orphaned raw video files (32-char hex names).
+`cleanupRawVideoFiles()` handles this — always call it in `afterAll`.
+
+## Discovering POM APIs
+
+Read the actual Page Object Models to see current locators and methods:
+
+```bash
+# List all POMs
+ls tests/playwright/src/model/
+
+# Read a specific POM for its locators and methods
+cat tests/playwright/src/model/bootc-page.ts
+
+# List all test utilities
+cat tests/playwright/src/utility/bootc-test-utils.ts
+```

--- a/.agents/skills/svelte-ui-design/SKILL.md
+++ b/.agents/skills/svelte-ui-design/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: svelte-ui-design
+description: >-
+  Guides designing and building Svelte 5 UI components in the bootc extension.
+  Covers @podman-desktop/ui-svelte components, Tailwind CSS, Svelte 5 runes,
+  page layouts, tables, forms, and upstream component patterns. Triggers when
+  creating or modifying Svelte components, building UI pages or forms, working
+  with the component library, or asking about frontend design patterns.
+paths:
+  - packages/frontend/src/**/*.svelte
+  - packages/frontend/src/**/*.ts
+  - packages/frontend/src/**/*.css
+---
+
+# Svelte UI Design Guide
+
+## Component Library Priority
+
+**Always use `@podman-desktop/ui-svelte` first.** This library provides
+Podman Desktop's design system. Only create custom components when the library
+does not cover the use case.
+
+- Source: https://github.com/podman-desktop/podman-desktop/tree/main/packages/ui
+- Storybook: https://podman-desktop.io/storybook
+
+```svelte
+<script lang="ts">
+import { Button, Input, Table, FormPage, NavPage, EmptyScreen } from '@podman-desktop/ui-svelte';
+</script>
+```
+
+### Check API
+
+Component APIs change across versions. Read the installed package directly:
+
+1. **List all exports**: Read `node_modules/@podman-desktop/ui-svelte/dist/index.d.ts`
+2. **Check component props**: Read the `.d.ts` file for any component, e.g.
+   `node_modules/@podman-desktop/ui-svelte/dist/button/Button.svelte.d.ts`
+3. **Browse all component dirs**: `ls node_modules/@podman-desktop/ui-svelte/dist/`
+4. **Check package exports**: Read `node_modules/@podman-desktop/ui-svelte/package.json`
+   for the full `exports` map (shows all importable paths)
+5. **See how we already use them**: `grep -r "from '@podman-desktop/ui-svelte'" packages/frontend/src/`
+
+Always verify props against the actual `.d.ts` files before using a component.
+
+## Svelte 5 Runes (Required)
+
+This project uses **Svelte 5 runes**. Never use legacy Svelte 4 reactive syntax.
+
+```svelte
+<script lang="ts">
+// Correct: Svelte 5 runes
+let items = $state<MyItem[]>([]);
+let loading = $state(true);
+let filtered = $derived(items.filter(i => i.active));
+
+$effect(() => {
+  fetchItems().then(result => {
+    items = result;
+    loading = false;
+  });
+});
+
+// Wrong: Legacy Svelte 4
+// $: filtered = items.filter(i => i.active);
+// let items = writable([]);
+</script>
+```
+
+### Props Pattern
+
+```svelte
+<script lang="ts">
+// Svelte 5 props with defaults
+let {
+  title,
+  items = [],
+  onselect,
+}: {
+  title: string;
+  items?: MyItem[];
+  onselect?: (item: MyItem) => void;
+} = $props();
+</script>
+```
+
+## Routing
+
+Hash-based routing via `tinro`. Routes are defined in `App.svelte`.
+
+```svelte
+<!-- App.svelte -->
+<Route path="/my-feature" breadcrumb="My Feature">
+  <MyFeature />
+</Route>
+
+<!-- Add navigation entry in Navigation.svelte -->
+<SettingsNavItem title="My Feature" href="/my-feature" icon={faMyIcon} selected={meta.url.startsWith('/my-feature')} />
+```
+
+Navigate programmatically:
+
+```typescript
+import { router } from 'tinro';
+router.goto('/disk-images/build');
+```
+
+Navigation helpers are in `packages/frontend/src/lib/navigation.ts`.
+
+## RPC Reactive Stores
+
+Auto-refreshing stores that subscribe to backend messages:
+
+```typescript
+import { rpcReadable } from '/@/stores/rpcReadable';
+import { bootcClient } from '/@/api/client';
+import { Messages } from '/@shared/src/messages/Messages';
+
+export const imageInfos = rpcReadable<ImageInfo[]>([], Messages.MSG_IMAGE_UPDATE, () => bootcClient.listBootcImages());
+```
+
+Use in components:
+
+```svelte
+<script lang="ts">
+import { imageInfos } from '/@/stores/imageInfo';
+let images = $derived($imageInfos);
+</script>
+```
+
+## Tailwind CSS
+
+Use Podman Desktop CSS variables (`var(--pd-*)`) for all theme-dependent styles.
+Font sizes are smaller than Tailwind defaults (text-base = 12px).
+
+Common variables: `--pd-content-card-bg`, `--pd-content-text`, `--pd-content-header`,
+`--pd-content-divider`, `--pd-button-primary-bg`.
+
+For the full Tailwind config (custom font sizes, content paths, theme overrides):
+
+```bash
+cat packages/frontend/tailwind.config.js
+```
+
+Grep existing components for CSS variable usage patterns:
+
+```bash
+grep -rn "var(--pd-" packages/frontend/src/ | head -30
+```
+
+## Upstream Components
+
+Local components in `packages/frontend/src/lib/upstream/` provide patterns not
+covered by `@podman-desktop/ui-svelte`. Browse them to find available components:
+
+```bash
+ls packages/frontend/src/lib/upstream/
+```
+
+## Checklist: Adding a New UI Page
+
+1. Create the component in `packages/frontend/src/` or `src/lib/`
+2. Add route in `App.svelte` using `<Route path="..." />`
+3. Add navigation entry in `Navigation.svelte` using `<SettingsNavItem />`
+4. Use the appropriate layout: `NavPage` (list), `FormPage` (form), or `DetailsPage` (detail)
+5. Use `@podman-desktop/ui-svelte` components for all standard UI elements
+6. Connect to backend via `bootcClient` from `/@/api/client`
+7. Add empty state with `EmptyScreen` or `FilteredEmptyScreen`
+8. Run `pnpm svelte:check` to validate component types
+9. Test with `pnpm watch` + Podman Desktop dev mode

--- a/.agents/skills/unit-testing/SKILL.md
+++ b/.agents/skills/unit-testing/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: unit-testing
+description: >-
+  Guides writing and maintaining Vitest unit tests for the bootc extension's
+  backend, frontend, and shared packages. Covers mocking @podman-desktop/api,
+  RPC clients, Svelte stores, and Node.js modules. Triggers when creating or
+  modifying .spec.ts files, fixing Vitest failures, or adding test coverage.
+paths:
+  - packages/backend/src/**/*.spec.ts
+  - packages/frontend/src/**/*.spec.ts
+  - packages/shared/src/**/*.spec.ts
+argument-hint: '[test-file-or-pattern]'
+---
+
+# Unit Testing for Bootc Extension
+
+## Framework
+
+- **Vitest 4** with v8 coverage provider
+- **Backend**: Node.js environment, mocked `@podman-desktop/api`
+- **Frontend**: JSDOM environment, `@testing-library/svelte` for components
+- **Shared**: Node.js environment for message proxy and model tests
+
+## Running Tests
+
+```bash
+pnpm test              # all packages
+pnpm test:backend      # packages/backend with coverage
+pnpm test:frontend     # packages/frontend with coverage
+pnpm test:shared       # packages/shared with coverage
+
+# Single file
+npx vitest run packages/backend/src/build-disk-image.spec.ts
+
+# Watch mode
+npx vitest watch packages/backend/src/
+```
+
+## Backend Test Patterns
+
+### Mocking @podman-desktop/api
+
+The backend's `vite.config.js` aliases `@podman-desktop/api` to a mock file.
+Mock only the namespaces your test actually uses:
+
+```typescript
+import { vi, test, expect, beforeEach, describe } from 'vitest';
+import * as extensionApi from '@podman-desktop/api';
+
+vi.mock('@podman-desktop/api', async () => ({
+  // Mock only what your test needs — check existing tests for patterns:
+  // grep -l "vi.mock('@podman-desktop/api'" packages/backend/src/*.spec.ts
+}));
+```
+
+To see the full mock shape used in existing tests:
+
+```bash
+grep -A 30 "vi.mock('@podman-desktop/api'" packages/backend/src/*.spec.ts | head -60
+```
+
+### Testing Backend Functions
+
+```typescript
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { buildDiskImage } from './build-disk-image';
+
+vi.mock('@podman-desktop/api');
+vi.mock('./container-utils');
+vi.mock('./history');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('buildDiskImage', () => {
+  test('should create build container with correct volumes', async () => {
+    // Arrange
+    const buildInfo = {
+      id: 'test-id',
+      image: 'quay.io/test/image',
+      tag: 'latest',
+      type: ['qcow2'] as BuildType[],
+      folder: '/output',
+      // ...
+    };
+
+    // Act
+    await buildDiskImage(buildInfo);
+
+    // Assert
+    expect(containerEngine.createContainer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        Image: expect.stringContaining('bootc-image-builder'),
+      }),
+    );
+  });
+});
+```
+
+### Mocking Node.js Modules
+
+```typescript
+import { vi } from 'vitest';
+
+vi.mock('node:fs', async () => ({
+  promises: {
+    mkdir: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+  },
+  existsSync: vi.fn(),
+}));
+
+vi.mock('node:child_process', async () => ({
+  exec: vi.fn(),
+}));
+```
+
+## Frontend Test Patterns
+
+### Component Testing with @testing-library/svelte
+
+```typescript
+import { vi, test, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import '@testing-library/jest-dom/vitest';
+import MyComponent from './MyComponent.svelte';
+
+// Mock the RPC client
+vi.mock('/@/api/client', async () => ({
+  bootcClient: {
+    listBootcImages: vi.fn().mockResolvedValue([]),
+    buildImage: vi.fn(),
+  },
+  rpcBrowser: {
+    subscribe: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+  },
+}));
+
+test('renders heading', async () => {
+  render(MyComponent, { props: { imageName: 'test' } });
+  expect(screen.getByText('Build Disk Image')).toBeInTheDocument();
+});
+
+test('clicking build button triggers build', async () => {
+  render(MyComponent);
+  const buildButton = screen.getByRole('button', { name: 'Build' });
+  await fireEvent.click(buildButton);
+  expect(bootcClient.buildImage).toHaveBeenCalled();
+});
+```
+
+### Mocking Svelte Stores
+
+```typescript
+import { vi } from 'vitest';
+import { readable } from 'svelte/store';
+
+vi.mock('/@/stores/imageInfo', async () => ({
+  imageInfos: readable([{ Id: 'abc123', RepoTags: ['quay.io/test:latest'], Labels: { 'containers.bootc': '' } }]),
+}));
+```
+
+### Path Aliases in Tests
+
+Frontend tests resolve `/@/` to `packages/frontend/src/` and `/@shared/` to
+`packages/shared/` via Vite config. Use these aliases in mocks:
+
+```typescript
+vi.mock('/@/api/client'); // → packages/frontend/src/api/client
+vi.mock('/@shared/src/models/bootc'); // → packages/shared/src/models/bootc
+```
+
+## Shared Package Tests
+
+### MessageProxy Tests
+
+```typescript
+import { test, expect, vi } from 'vitest';
+import { RpcBrowser, RpcExtension } from './MessageProxy';
+
+test('RPC call resolves with result', async () => {
+  // Test the RPC proxy mechanism
+});
+```
+
+## Test File Naming
+
+- Test files: `*.spec.ts` colocated with source files
+- Example: `build-disk-image.ts` → `build-disk-image.spec.ts`
+
+## Coverage
+
+Coverage reports are generated in `lcov` and `text` format:
+
+```bash
+pnpm test:backend   # generates packages/backend/coverage/
+pnpm test:frontend  # generates packages/frontend/coverage/
+```
+
+## Common Issues
+
+### "Cannot find module @podman-desktop/api"
+
+The mock alias is configured in `packages/backend/vite.config.js`. If you see
+this error, ensure the test file is being run from the correct package.
+
+### "Not a Svelte component"
+
+The test environment needs the Svelte vite plugin. Frontend tests use the
+config from `packages/frontend/vite.config.js` which includes `@sveltejs/vite-plugin-svelte`.
+
+### Test Retries
+
+Frontend tests retry failed tests 2x (configured in `packages/frontend/vite.config.js`).
+Backend tests do not retry.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,122 @@
+# AGENTS.md
+
+## Project Overview
+
+Bootable Container (bootc) extension for Podman Desktop. Converts container images
+with bootc labels (`ostree.bootable`, `containers.bootc`) into bootable disk images
+(qcow2, ami, raw, vmdk, vhd, gce, anaconda-iso) using bootc-image-builder. Also
+manages Macadam-based virtual machines from built disk images.
+
+- **Tech stack**: TypeScript, Svelte 5, Tailwind CSS, Vite, pnpm
+- **Monorepo**: pnpm workspaces with three packages — `backend`, `frontend`, `shared`
+- **Extension API**: `@podman-desktop/api`
+- **VM management**: `@crc-org/macadam.js` (Apple HV, WSL, Hyper-V)
+- **Test frameworks**: Vitest (unit), Playwright with `@podman-desktop/tests-playwright` (E2E)
+- **License**: Apache-2.0
+
+## Quick Start
+
+```sh
+pnpm install
+pnpm build
+```
+
+## Essential Commands
+
+```sh
+# Build
+pnpm build                    # build all packages (frontend → backend/media/)
+
+# Test
+pnpm test                     # all unit tests (backend + frontend + shared)
+pnpm test:backend             # backend unit tests with coverage
+pnpm test:frontend            # frontend unit tests with coverage
+pnpm test:shared              # shared unit tests with coverage
+pnpm test:e2e                 # playwright E2E tests
+
+# Lint & Format
+pnpm lint:check               # ESLint check
+pnpm lint:fix                 # ESLint fix
+pnpm format:check             # Biome + Prettier check
+pnpm format:fix               # Biome + Prettier fix
+pnpm typecheck                # TypeScript type checking across all packages
+pnpm svelte:check             # Svelte component validation
+
+# Pre-PR checklist (run all of these)
+pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm test
+```
+
+## Skills
+
+Task-specific guidance lives in `.agents/skills/`:
+
+- `extension-development` — end-to-end feature work across backend/frontend
+- `backend-api` — backend and RPC changes
+- `svelte-ui-design` — Svelte 5 and Podman Desktop UI patterns
+- `unit-testing` — Vitest patterns for backend/frontend/shared
+- `playwright-testing` — E2E structure, lifecycle, and commands
+
+## Architecture
+
+Frontend (Svelte webview) ←→ RPC (postMessage via MessageProxy) ←→ Backend (Node.js)
+
+- **Frontend**: `App.svelte`, stores — see **svelte-ui-design** skill
+- **Backend**: `extension.ts`, `BootcApiImpl`, `@podman-desktop/api` — see **backend-api** skill
+- **Shared**: `BootcAPI` contract, models, messages
+
+Three packages under `packages/`:
+
+- **`backend/`** — Extension entry point (Node.js). Entry: `src/extension.ts`, RPC handler: `src/api-impl.ts`. Built output: `dist/extension.js`
+- **`frontend/`** — Svelte 5 webview UI. Root router: `src/App.svelte`. Builds to `../backend/media/`
+- **`shared/`** — Shared types and RPC. API contract: `src/BootcAPI.ts`, models: `src/models/`, messages: `src/messages/`
+- **`tests/playwright/`** — E2E tests with Page Object Models in `src/model/`
+
+### Communication
+
+Frontend ↔ Backend via RPC MessageProxy over webview postMessage:
+
+- `RpcExtension` (backend) registers `BootcApiImpl`
+- `RpcBrowser` (frontend) calls methods via `api/client.ts`
+- Notification messages defined in `packages/shared/src/messages/Messages.ts`
+
+### Extension Registration
+
+Extension points (commands, menus, configuration, icons, views) are defined in
+`packages/backend/package.json` under `contributes`.
+
+## Coding Guidelines
+
+### Svelte Patterns
+
+This project uses **Svelte 5 runes** (`$state`, `$derived`, `$effect`). Do NOT use legacy reactive syntax (`$:`, `let x = writable()`). For concrete layout, store, and component patterns, use `.agents/skills/svelte-ui-design/SKILL.md`.
+
+### Testing Patterns
+
+Use `.agents/skills/unit-testing/SKILL.md` for unit-test patterns and `.agents/skills/playwright-testing/SKILL.md` for E2E patterns. Backend tests mock `@podman-desktop/api`, frontend tests use `@testing-library/svelte`, and path aliases remain `/@/` → `src/`, `/@shared/` → `../../shared/`.
+
+### Commit Conventions
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```text
+feat: add VHD build type support
+fix: handle missing SSH key gracefully
+chore: bump eslint-plugin-unicorn
+docs: update RELEASE.md with E2E instructions
+```
+
+Enforced by commitlint + husky pre-commit hooks.
+
+### Import Path Aliases
+
+Use aliases for import paths.
+
+```typescript
+// Backend
+import { foo } from '/@/bar'; // → packages/backend/src/bar
+import { Baz } from '/@shared/src/x'; // → packages/shared/src/x
+
+// Frontend
+import { foo } from '/@/bar'; // → packages/frontend/src/bar
+import { Baz } from '/@shared/src/x'; // → packages/shared/src/x
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
feat(agents): add agents + skills to bootc extension

### What does this PR do?

Adds agents / claude markdown files as well as a set of folders that
I've been using for the past while organized into separate skills.

This includes:
- backend
- frontend
- playwright testing
- svelte UI design (emphasis on using components)
- unit testing

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/2522

### How to test this PR?

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
