### PR TITLE
chore(navbar): fix alignment

### DIFF
--- a/packages/frontend/src/Navigation.svelte
+++ b/packages/frontend/src/Navigation.svelte
@@ -21,17 +21,11 @@ let { meta }: Props = $props();
       <p class="text-xl font-semibold text-[color:var(--pd-secondary-nav-header-text)] border-l-[4px] border-transparent">Bootable Containers</p>
     </a>
   </div>
-  <div class="h-full overflow-y-auto" style="margin-bottom:auto">
-    <!-- FontAwesome icons rendered via SettingsNavItem are slightly narrower than custom Svelte component icons
-         (which get wrapped in a <span> by the Icon component). The pl-[1px] compensates for this alignment difference. -->
-    <div class="pl-[1px]">
-      <SettingsNavItem title="Dashboard" icon={faHouse} selected={meta.url === '/'} href="/" />
-    </div>
+  <div class="h-full overflow-y-auto [&_svg]:w-[1.25em] [&_span[role=img]]:w-[1.25em]" style="margin-bottom:auto">
+    <SettingsNavItem title="Dashboard" icon={faHouse} selected={meta.url === '/'} href="/" />
     <SettingsNavItem title="Images" icon={BootcImageIcon} selected={meta.url.startsWith('/images')} href="/images" />
     <SettingsNavItem title="Disk Images" icon={DiskImageIcon} selected={meta.url.startsWith('/disk-image')} href="/disk-images" />
-    <div class="pl-[1px]">
-      <SettingsNavItem title="Examples" icon={faBookOpen} selected={meta.url.startsWith('/examples')} href="/examples" />
-    </div>
+    <SettingsNavItem title="Examples" icon={faBookOpen} selected={meta.url.startsWith('/examples')} href="/examples" />
   </div>
 </nav>
 


### PR DESCRIPTION
chore(navbar): fix alignment

### What does this PR do?

Been bothering me whne developing, the VERY SLIGHT misalignment on the
navbar.

After some researching, finally found a permanent solution.

The cause was the icons for font awesome having slight differentiation
for each one, causing a shift in the text.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:
<img width="312" height="398" alt="Screenshot 2026-05-18 at 9 45 04 PM" src="https://github.com/user-attachments/assets/4f14d6a6-a596-4d8b-8b64-701318a0d7a5" />

After:

<img width="312" height="398" alt="Screenshot 2026-05-18 at 9 45 31 PM" src="https://github.com/user-attachments/assets/201b0302-a6bf-4fa5-a08e-366b9ef2b8af" />




### What issues does this PR fix or reference?

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
