### PR TITLE
chore: improve agentready score with config, rules, and hooks

### DIFF
--- a/.agentready-config.yaml
+++ b/.agentready-config.yaml
@@ -1,0 +1,24 @@
+excluded_attributes:
+  # Not a REST API — this is a desktop extension using RPC over postMessage
+  - openapi_specs
+
+  # Not applicable to this project's language/stack
+  - container_setup
+  - dbt_project_config
+  - dbt_model_documentation
+  - dbt_data_tests
+  - dbt_project_structure
+
+  # pnpm monorepo with packages/*/src/ — tool only checks for root src/
+  - standard_layout
+
+  # AGENTS.md/CLAUDE.md and .agents/skills/ already provide AI context
+  - repomix_config
+
+  # Architecture is documented in AGENTS.md/CLAUDE.md under architecture section
+  - architecture_decisions
+
+  # Monorepo false positive — all packages have strict:true in their tsconfig.json already,
+  # but bug does not pick it up
+  # See: https://github.com/ambient-code/agentready/issues/431
+  - type_annotations

--- a/.agents/rules/backend.md
+++ b/.agents/rules/backend.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - 'packages/backend/**/*.ts'
+---
+
+Backend runs in Node.js. Mock @podman-desktop/api in tests. Path aliases: /@/ → src/, /@shared/ → ../../shared/.
+
+New API methods require: shared interface update, backend implementation in api-impl.ts, frontend client usage.

--- a/.agents/rules/frontend.md
+++ b/.agents/rules/frontend.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - 'packages/frontend/**/*.svelte'
+  - 'packages/frontend/**/*.ts'
+---
+
+Use Svelte 5 runes ($state, $derived, $effect). Never use legacy $: reactive syntax or writable() stores.
+
+Frontend tests use @testing-library/svelte with vitest. Path aliases: /@/ → src/, /@shared/ → ../../shared/.

--- a/.agents/rules/shared.md
+++ b/.agents/rules/shared.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - 'packages/shared/**/*.ts'
+---
+
+Shared package defines the BootcAPI contract, models, and notification messages. Changes here affect both backend and frontend.
+
+BootcAPI interface is the RPC contract — keep it in sync with BootcApiImpl in the backend.

--- a/.claude/rules
+++ b/.claude/rules
@@ -1,0 +1,1 @@
+../.agents/rules

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm exec biome format --write \"$CLAUDE_FILE_PATH\" 2>/dev/null; pnpm exec prettier --cache --write \"$CLAUDE_FILE_PATH\" 2>/dev/null; exit 0"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm exec eslint --cache --fix \"$CLAUDE_FILE_PATH\" 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"$CLAUDE_TOOL_INPUT\" | grep -qE '(rm -rf|git push --force|git reset --hard|git checkout \\.)' && echo 'BLOCK: Destructive operation detected. Please confirm with the user first.' && exit 1 || exit 0"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/backend-api
+++ b/.claude/skills/backend-api
@@ -1,0 +1,1 @@
+../../.agents/skills/backend-api

--- a/.claude/skills/extension-development
+++ b/.claude/skills/extension-development
@@ -1,0 +1,1 @@
+../../.agents/skills/extension-development

--- a/.claude/skills/playwright-testing
+++ b/.claude/skills/playwright-testing
@@ -1,0 +1,1 @@
+../../.agents/skills/playwright-testing

--- a/.claude/skills/svelte-ui-design
+++ b/.claude/skills/svelte-ui-design
@@ -1,0 +1,1 @@
+../../.agents/skills/svelte-ui-design

--- a/.claude/skills/unit-testing
+++ b/.claude/skills/unit-testing
@@ -1,0 +1,1 @@
+../../.agents/skills/unit-testing

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ output
 test-results
 yarn.lock
 .yarnrc
+*.swp
+*.swo
+*.tsbuildinfo
+.npm/
+.vscode/
+.agentready/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,26 @@ pnpm svelte:check             # Svelte component validation
 pnpm format:fix && pnpm lint:fix && pnpm typecheck && pnpm test
 ```
 
+## Single-File Verification
+
+Lint, type-check, and test a single file without a full build:
+
+```sh
+# Lint single file
+npx eslint path/to/file.ts
+
+# Type-check single file
+npx tsc --noEmit path/to/file.ts
+
+# Type-check by package (when cross-package imports are involved)
+npx tsc --noEmit -p packages/backend/tsconfig.json
+npx tsc --noEmit -p packages/frontend/tsconfig.json
+npx tsc --noEmit -p packages/shared/tsconfig.json
+
+# Test single file
+pnpm vitest run path/to/file.spec.ts
+```
+
 ## Skills
 
 Task-specific guidance lives in `.agents/skills/`:
@@ -83,6 +103,14 @@ Frontend ↔ Backend via RPC MessageProxy over webview postMessage:
 
 Extension points (commands, menus, configuration, icons, views) are defined in
 `packages/backend/package.json` under `contributes`.
+
+## Pattern References
+
+- New backend API method: follow `packages/shared/src/BootcAPI.ts` (interface), `packages/backend/src/api-impl.ts` (implementation)
+- New Svelte page/component: follow `packages/frontend/src/Build.svelte` as reference
+- New unit test: follow `packages/backend/src/api-impl.spec.ts` (backend) or `packages/frontend/src/Build.spec.ts` (frontend)
+- New E2E test: follow `tests/playwright/src/bootc-extension.spec.ts`
+- New shared model: follow `packages/shared/src/models/bootc.ts`
 
 ## Coding Guidelines
 


### PR DESCRIPTION
chore: improve agentready score with config, rules, and hooks

### What does this PR do?

Improves the agentready AI-readiness score from
56.3/100 (Bronze) to 72.0/100 (Silver) by adding
config, path-scoped rules,

I also had to add a few to exclusions because it doesn't relate to our
project (or there are current bugs, etc.

### What issues does this PR fix or reference?

https://github.com/podman-desktop/extension-bootc/issues/2531

### How to test this PR?

Run agentready assess with --config .agentready-config.yaml
and verify score is ~72+.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Charlie Drage <charlie@charliedrage.com>
