### PR TITLE
chore: add repository/homepage fields to extension package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "displayName": "Bootable Container",
   "description": "Support for bootable OS containers (bootc) and generating disk images",
   "repository": "https://github.com/podman-desktop/extension-bootc",
+  "homepage": "https://github.com/podman-desktop/extension-bootc#readme",
   "version": "1.15.0-next",
   "icon": "icon.png",
   "publisher": "redhat",


### PR DESCRIPTION
### What does this PR do?

Add missing `repository` and `homepage` fields in the extension `package.json`.

### Screenshot / video of UI

N/A (metadata-only change)

### What issues does this PR fix or reference?

Closes #2501

### How to test this PR?

1. Open `package.json`.
2. Verify both `repository` and `homepage` are present and point to this GitHub repository.
3. Confirm no other files changed.
