### PR TITLE
fix: resolve CVE-2026-45149 in brace-expansion 

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
       "ajv@<6.14.0": ">=6.14.0 <7.0.0",
       "yaml@>=2.0.0 <2.8.3": ">=2.8.3",
       "postcss@<8.5.10": ">=8.5.10",
-      "fast-uri@<3.1.2": ">=3.1.2"
+      "fast-uri@<3.1.2": ">=3.1.2",
+      "brace-expansion@>=5.0.0 <5.0.6": ">=5.0.6"
     },
     "ignoredBuiltDependencies": [
       "@biomejs/biome",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   yaml@>=2.0.0 <2.8.3: '>=2.8.3'
   postcss@<8.5.10: '>=8.5.10'
   fast-uri@<3.1.2: '>=3.1.2'
+  brace-expansion@>=5.0.0 <5.0.6: '>=5.0.6'
 
 importers:
 
@@ -1800,8 +1801,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5307,7 +5308,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6546,7 +6547,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-45149 in `brace-expansion`.

**Advisory**: brace-expansion: Large numeric range defeats documented `max` DoS protection
**Vulnerable versions**: >=5.0.0 <5.0.6
**Patched versions**: >=5.0.6
**Advisory URL**: https://github.com/advisories/GHSA-jxxr-4gwj-5jf2

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-45149: _brace-expansion: Large numeric range defeats documented `max` DoS protection_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-45149 is no longer reported