### PR TITLE
feat(macadam): propagate lifecycle errors to connection error property

### DIFF
--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -383,18 +383,36 @@ async function registerProviderFor(
 ): Promise<void> {
   const lifecycle: extensionApi.ProviderConnectionLifecycle = {
     start: async (context, logger): Promise<void> => {
-      await startMachine(provider, machineInfo, context, logger);
+      try {
+        await startMachine(provider, machineInfo, context, logger);
+        vmProviderConnection.error = undefined;
+      } catch (err) {
+        vmProviderConnection.error = err instanceof Error ? err.message : String(err);
+        throw err;
+      }
     },
     stop: async (context, logger): Promise<void> => {
-      await stopMachine(provider, machineInfo, context, logger);
+      try {
+        await stopMachine(provider, machineInfo, context, logger);
+        vmProviderConnection.error = undefined;
+      } catch (err) {
+        vmProviderConnection.error = err instanceof Error ? err.message : String(err);
+        throw err;
+      }
     },
     delete: async (logger): Promise<void> => {
-      await ensureMacadamInitialized(true);
-      await macadam.removeVm({
-        name: machineInfo.name,
-        containerProvider: verifyContainerProivder(machineInfo.vmType),
-        runOptions: { logger },
-      });
+      try {
+        await ensureMacadamInitialized(true);
+        await macadam.removeVm({
+          name: machineInfo.name,
+          containerProvider: verifyContainerProivder(machineInfo.vmType),
+          runOptions: { logger },
+        });
+        vmProviderConnection.error = undefined;
+      } catch (err) {
+        vmProviderConnection.error = err instanceof Error ? err.message : String(err);
+        throw err;
+      }
     },
   };
 


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

Propagates lifecycle errors (start, stop, delete) to the VM provider connection's `error` property. When operation fails, the error is now surfaced on the connection object via `connection.error`. On success, any previous error is cleared.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes podman-desktop/extension-bootc#2481
Part of podman-desktop/podman-desktop#17222

### How to test this PR?

1. Force an error in start/stop/delete (e.g. inject a throw inside each lifecycle action)
2. Try to start/stop/delete the VM
3. Verify error message propagated
4. Perform a successful operation and verify the error is cleared

- [ ] Tests are covering the bug fix or the new feature