### PR TITLE
fix: resolve CVE-2026-9277 in shell-quote

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
       "yaml@>=2.0.0 <2.8.3": ">=2.8.3",
       "postcss@<8.5.10": ">=8.5.10",
       "fast-uri@<3.1.2": ">=3.1.2",
-      "brace-expansion@>=5.0.0 <5.0.6": ">=5.0.6"
+      "brace-expansion@>=5.0.0 <5.0.6": ">=5.0.6",
+      "shell-quote@>=1.1.0 <1.8.4": ">=1.8.4"
     },
     "ignoredBuiltDependencies": [
       "@biomejs/biome",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   postcss@<8.5.10: '>=8.5.10'
   fast-uri@<3.1.2: '>=3.1.2'
   brace-expansion@>=5.0.0 <5.0.6: '>=5.0.6'
+  shell-quote@>=1.1.0 <1.8.4: '>=1.8.4'
 
 importers:
 
@@ -3215,8 +3216,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
@@ -5199,7 +5200,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -6689,7 +6690,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.0:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix critical severity vulnerability CVE-2026-9277 in `shell-quote`.

**Advisory**: shell-quote quote() does not escape newlines in object .op values
**Vulnerable versions**: >=1.1.0 <=1.8.3
**Patched versions**: >=1.8.4
**Advisory URL**: https://github.com/advisories/GHSA-w7jw-789q-3m8p

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-9277: _shell-quote quote() does not escape newlines in object .op values_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-9277 is no longer reported