### PR TITLE
fix(docs): update Podman repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.10.0+](https://github.com/podman-desktop/podman-desktop)
-- [Podman 5.0.1+](https://github.com/containers/podman)
+- [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Podman Machine (macOS / Windows)
 


### PR DESCRIPTION
### What does this PR do?
Updates the Podman prerequisite link to the new `podman-container-tools/podman` repository.

### Screenshot / video of UI

N/A (documentation-only change)

### What issues does this PR fix or reference?
- containers/podman-desktop-internal#983

### How to test this PR?
- Open `README.md` and verify the Podman prerequisite points to `https://github.com/podman-container-tools/podman`.

Made with [Cursor](https://cursor.com)