### PR TITLE
chore: add schema URL to bootc extension manifest

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://www.schemastore.org/podman-desktop-extension-1.27.json",
   "name": "bootc",
   "displayName": "Bootable Container",
   "description": "Support for bootable OS containers (bootc) and generating disk images",


### PR DESCRIPTION
### What does this PR do?

Adds the SchemaStore `$schema` reference to `packages/backend/package.json` so the bootc extension manifest is validated against the Podman Desktop extension schema.

### Screenshot / video of UI
<img width="822" height="548" alt="Screenshot 2026-06-11 at 12 59 01" src="https://github.com/user-attachments/assets/aa7fe5fc-459a-4af0-84f6-c8891adc689a" />

<img width="822" height="548" alt="Screenshot 2026-06-11 at 12 59 36" src="https://github.com/user-attachments/assets/b8cde945-61d2-4665-bcf5-c8061f3fc04d" />

### What issues does this PR fix or reference?

References https://github.com/podman-desktop/podman-desktop/issues/16052

### How to test this PR?

1. Open `packages/backend/package.json` in an editor with JSON schema support.
2. Verify schema URL is set to `https://www.schemastore.org/podman-desktop-extension-1.27.json`.
3. Confirm schema-driven validation/autocomplete is available for extension manifest fields.

Made with [Cursor](https://cursor.com)