### PR TITLE
chore(docs): clarify wsl2/hyper-v windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Podman Machine requirements:
 
 - **Rootful mode enabled**
 - _At least_ 6GB of RAM allocated in order to build the disk image
+- (Windows) WSL2 Podman Machine
 
 Rootful mode can be enabled through the CLI to an already deployed VM:
 
@@ -201,7 +202,7 @@ Your public key information (ex. `ssh-ed25519 AAABBBCCC...`) from `~/.ssh/id_ed2
 
 ![Escalated privileges prompt](https://raw.githubusercontent.com/podman-desktop/podman-desktop-extension-bootc/main/docs/img/escalated_privileges.png)
 
-> **Note (Windows):** Windows support is currently _not supported_ due to Hyper-V limitations (must run as a privileged user), WSL2 support is _not supported_ due to Windows using a custom kernel for Virtual Machine usage which is incompatible with bootc-based images.
+> **Note (Windows):** Virtual Machine testing with Windows support is currently _not supported_ due to Hyper-V limitations (must run as a privileged user), WSL2 support is also _not supported_ due to Windows using a custom kernel for Virtual Machine usage which is incompatible with bootc-based images.
 
 ## Advanced usage
 


### PR DESCRIPTION
chore(docs): clarify wsl2/hyper-v windows support

### What does this PR do?

Clarify that when creating a Podman Machine for Windows it must be WSL2.

Also clarify that the WSL2/Hyper-V not supported is ONLY for Virtual
Machine testing.

Had a few issues where I'd ctrl+f the README.md for reference and
mistakenly got confused between WSL2/Hyper-V compatibility... this PR
updates the README.md to clarify it a bit better.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to clarify Windows Podman Machine prerequisites, including WSL2 Podman Machine.
  * Refined the Windows usage note to better explain unsupported virtual machine testing and WSL2 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->