### PR TITLE
fix: resolve CVE-2026-9697 in undici

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
       "postcss@<8.5.10": ">=8.5.10",
       "fast-uri@<3.1.2": ">=3.1.2",
       "brace-expansion@>=5.0.0 <5.0.6": ">=5.0.6",
-      "shell-quote@>=1.1.0 <1.8.4": ">=1.8.4"
+      "shell-quote@>=1.1.0 <1.8.4": ">=1.8.4",
+      "undici@>=7.23.0 <7.28.0": ">=7.28.0"
     },
     "ignoredBuiltDependencies": [
       "@biomejs/biome",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   fast-uri@<3.1.2: '>=3.1.2'
   brace-expansion@>=5.0.0 <5.0.6: '>=5.0.6'
   shell-quote@>=1.1.0 <1.8.4: '>=1.8.4'
+  undici@>=7.23.0 <7.28.0: '>=7.28.0'
 
 importers:
 
@@ -3568,9 +3569,9 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
-    engines: {node: '>=20.18.1'}
+  undici@8.7.0:
+    resolution: {integrity: sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==}
+    engines: {node: '>=22.19.0'}
 
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
@@ -6189,7 +6190,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 8.7.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -7069,7 +7070,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.25.0: {}
+  undici@8.7.0: {}
 
   unrs-resolver@1.12.2:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-9697 in `undici`.

**Advisory**: undici vulnerable to TLS certificate validation bypass via dropped requestTls in SOCKS5 ProxyAgent
**Vulnerable versions**: >=7.23.0 <7.28.0
**Patched versions**: >=7.28.0
**Advisory URL**: https://github.com/advisories/GHSA-vmh5-mc38-953g

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-9697: _undici vulnerable to TLS certificate validation bypass via dropped requestTls in SOCKS5 ProxyAgent_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-9697 is no longer reported