### PR TITLE
fix: resolve CVE-2026-13149 in brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,9 @@
       "yaml@>=2.0.0 <2.8.3": ">=2.8.3",
       "postcss@<8.5.10": ">=8.5.10",
       "fast-uri@<3.1.2": ">=3.1.2",
-      "brace-expansion@>=5.0.0 <5.0.6": ">=5.0.6",
+      "brace-expansion@<1.1.16": ">=1.1.16 <2.0.0",
+      "brace-expansion@>=2.0.0 <2.1.2": ">=2.1.2 <3.0.0",
+      "brace-expansion@>=5.0.0 <5.0.7": ">=5.0.7",
       "shell-quote@>=1.1.0 <1.8.4": ">=1.8.4"
     },
     "ignoredBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,9 @@ overrides:
   yaml@>=2.0.0 <2.8.3: '>=2.8.3'
   postcss@<8.5.10: '>=8.5.10'
   fast-uri@<3.1.2: '>=3.1.2'
-  brace-expansion@>=5.0.0 <5.0.6: '>=5.0.6'
+  brace-expansion@<1.1.16: '>=1.1.16 <2.0.0'
+  brace-expansion@>=2.0.0 <2.1.2: '>=2.1.2 <3.0.0'
+  brace-expansion@>=5.0.0 <5.0.7: '>=5.0.7'
   shell-quote@>=1.1.0 <1.8.4: '>=1.8.4'
 
 importers:
@@ -1711,14 +1713,14 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5079,16 +5081,16 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.0:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6281,15 +6283,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-13149 in `brace-expansion`.

**Advisory**: brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups
**Vulnerable versions**: >=2.0.0 <2.1.2
**Patched versions**: >=2.1.2
**Advisory URL**: https://github.com/advisories/GHSA-3jxr-9vmj-r5cp

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-13149: _brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-13149 is no longer reported