### PR TITLE
fix: resolve CVE-2026-59869 in js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@xterm/addon-attach": "^0.12.0",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.3.0"
   },
   "pnpm": {
     "overrides": {
@@ -97,7 +97,8 @@
       "brace-expansion@<1.1.16": ">=1.1.16 <2.0.0",
       "brace-expansion@>=2.0.0 <2.1.2": ">=2.1.2 <3.0.0",
       "brace-expansion@>=5.0.0 <5.0.7": ">=5.0.7",
-      "shell-quote@>=1.1.0 <1.9.0": ">=1.9.0"
+      "shell-quote@>=1.1.0 <1.9.0": ">=1.9.0",
+      "js-yaml": ">=4.3.0 <5.0.0"
     },
     "ignoredBuiltDependencies": [
       "@biomejs/biome",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   brace-expansion@>=2.0.0 <2.1.2: '>=2.1.2 <3.0.0'
   brace-expansion@>=5.0.0 <5.0.7: '>=5.0.7'
   shell-quote@>=1.1.0 <1.9.0: '>=1.9.0'
+  js-yaml: '>=4.3.0 <5.0.0'
 
 importers:
 
@@ -29,8 +30,8 @@ importers:
         specifier: ^0.12.0
         version: 0.12.0
       js-yaml:
-        specifier: ^4.2.0
-        version: 4.2.0
+        specifier: '>=4.3.0 <5.0.0'
+        version: 4.3.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.5
@@ -2621,8 +2622,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -4249,7 +4250,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5235,7 +5236,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -6107,7 +6108,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-59869 in `js-yaml`.

**Advisory**: js-yaml: YAML merge-key chains can force quadratic CPU consumption
**Vulnerable versions**: >=4.0.0 <4.3.0
**Patched versions**: >=4.3.0
**Advisory URL**: https://github.com/advisories/GHSA-52cp-r559-cp3m

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-59869: _js-yaml: YAML merge-key chains can force quadratic CPU consumption_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-59869 is no longer reported