### PR TITLE
chore(workflow): update release workflow to allow minor releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,18 +100,26 @@ jobs:
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${bumpedVersion}-next\",#g" packages/backend/package.json
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${bumpedVersion}-next\",#g" packages/frontend/package.json
           git add package.json packages/backend/package.json packages/frontend/package.json
-          git commit -s --amend -m "chore: bump version to ${bumpedVersion}"
-          git push origin "${bumpedBranchName}"
-          echo -e "📢 Bump version to ${bumpedVersion}\n\n${{ steps.TAG_UTIL.outputs.bootcExtensionVersion }} has been released.\n\n Time to switch to the new ${bumpedVersion} version 🥳" > /tmp/pr-title
-          pullRequestUrl=$(gh pr create --title "chore: 📢 Bump version to ${bumpedVersion}" --body-file /tmp/pr-title --head "${bumpedBranchName}" --base "main")
-          echo "📢 Pull request created: ${pullRequestUrl}"
-          echo "➡️ Flag the PR as being ready for review"
-          gh pr ready "${pullRequestUrl}"
-          echo "🔅 Mark the PR as being ok to be merged automatically"
-          gh pr merge "${pullRequestUrl}" --auto --rebase
-          sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${CURRENT_VERSION}\",#g" package.json
-          sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${CURRENT_VERSION}\",#g" packages/backend/package.json
-          sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${CURRENT_VERSION}\",#g" packages/frontend/package.json
+
+          # For patch releases (e.g. 1.14.1), main is already bumped to the
+          # next minor (e.g. 1.15.0-next) from the original minor release,
+          # so the amend would produce an empty commit. Skip the bump PR.
+          if git diff --cached --quiet HEAD~1; then
+            echo "ℹ️ Version on main is already at ${bumpedVersion}-next, skipping bump PR (patch release)"
+          else
+            git commit -s --amend -m "chore: bump version to ${bumpedVersion}"
+            git push origin "${bumpedBranchName}"
+            echo -e "📢 Bump version to ${bumpedVersion}\n\n${{ steps.TAG_UTIL.outputs.bootcExtensionVersion }} has been released.\n\n Time to switch to the new ${bumpedVersion} version 🥳" > /tmp/pr-title
+            pullRequestUrl=$(gh pr create --title "chore: 📢 Bump version to ${bumpedVersion}" --body-file /tmp/pr-title --head "${bumpedBranchName}" --base "main")
+            echo "📢 Pull request created: ${pullRequestUrl}"
+            echo "➡️ Flag the PR as being ready for review"
+            gh pr ready "${pullRequestUrl}"
+            echo "🔅 Mark the PR as being ok to be merged automatically"
+            gh pr merge "${pullRequestUrl}" --auto --rebase
+            sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${CURRENT_VERSION}\",#g" package.json
+            sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${CURRENT_VERSION}\",#g" packages/backend/package.json
+            sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${CURRENT_VERSION}\",#g" packages/frontend/package.json
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
chore(workflow): update release workflow to allow minor releases

### What does this PR do?

When doing a minor release, we get this error, example, doing a `1.14.1`
release:

```sh
Switched to a new branch 'bump-to-1.15.0'
You asked to amend the most recent commit, but doing so would make
On branch bump-to-1.15.0
No changes
it empty. You can repeat your command with --allow-empty, or you can
remove the commit entirely with "git reset HEAD^".
Error: Process completed with exit code 1.
```

It tries to create a PR to update the version even if it's already on
the next major version.

This update allows us to do minor versions fine.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A, discovered during the release process.

### How to test this PR?

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
